### PR TITLE
Dwarf: tracing function return value

### DIFF
--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/dwarf-tests/dwarf-functions-build/0x101__M.ll.debug_info.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/dwarf-tests/dwarf-functions-build/0x101__M.ll.debug_info.expected
@@ -60,8 +60,10 @@ entry:
   %insert_3 = insertvalue %struct.M__MyStruct %insert_2, i8 %fv.3, 3
   %insert_4 = insertvalue %struct.M__MyStruct %insert_3, %struct.M__Combined %fv.4, 4
   store %struct.M__MyStruct %insert_4, ptr %local_11, align 8
-  %retval = load %struct.M__MyStruct, ptr %local_11, align 8
-  ret %struct.M__MyStruct %retval
+  %retval = load %struct.M__MyStruct, ptr %local_11, align 8, !dbg !48
+  call void @llvm.dbg.declare(metadata ptr %local_11, metadata !49, metadata !DIExpression()), !dbg !48
+  call void @llvm.dbg.declare(metadata ptr %local_11, metadata !51, metadata !DIExpression()), !dbg !48
+  ret %struct.M__MyStruct %retval, !dbg !48
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
@@ -124,3 +126,8 @@ attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !45 = distinct !DILexicalBlock(scope: !2, file: !1, line: 39, column: 24)
 !46 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-functions.move_39_par_1_u8", scope: !47, file: !1, line: 39, type: !5)
 !47 = distinct !DILexicalBlock(scope: !2, file: !1, line: 39, column: 24)
+!48 = !DILocation(line: 46, column: 9, scope: !2)
+!49 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-functions.move_46_my_struct_copy", scope: !50, file: !1, line: 46, type: !29)
+!50 = distinct !DILexicalBlock(scope: !2, file: !1, line: 46, column: 9)
+!51 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-functions.move_46_my_struct_copy", scope: !52, file: !1, line: 46, type: !29)
+!52 = distinct !DILexicalBlock(scope: !2, file: !1, line: 46, column: 9)

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/dwarf-tests/dwarf-functions-build/0x201__M.ll.debug_info.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/dwarf-tests/dwarf-functions-build/0x201__M.ll.debug_info.expected
@@ -35,8 +35,10 @@ entry:
   %insert_0 = insertvalue %struct.M__MyStruct_2 undef, i32 %fv.0, 0
   %insert_1 = insertvalue %struct.M__MyStruct_2 %insert_0, %struct.M__MyStruct %fv.1, 1
   store %struct.M__MyStruct_2 %insert_1, ptr %local_5, align 8
-  %retval1 = load %struct.M__MyStruct_2, ptr %local_5, align 8
-  ret %struct.M__MyStruct_2 %retval1
+  %retval1 = load %struct.M__MyStruct_2, ptr %local_5, align 8, !dbg !46
+  call void @llvm.dbg.declare(metadata ptr %local_5, metadata !47, metadata !DIExpression()), !dbg !46
+  call void @llvm.dbg.declare(metadata ptr %local_5, metadata !49, metadata !DIExpression()), !dbg !46
+  ret %struct.M__MyStruct_2 %retval1, !dbg !46
 }
 
 declare %struct.M__MyStruct @"0000000000000101_M_fun_1_AcLtMspYikxikv"(i8, i1)
@@ -96,3 +98,8 @@ attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !43 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-functions.move_10_par_1_u32", scope: !44, file: !1, line: 10, type: !5)
 !44 = distinct !DILexicalBlock(scope: !2, file: !1, line: 10, column: 25)
 !45 = !DILocation(line: 11, column: 39, scope: !2)
+!46 = !DILocation(line: 14, column: 9, scope: !2)
+!47 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-functions.move_14_my_struct_copy_2", scope: !48, file: !1, line: 14, type: !11)
+!48 = distinct !DILexicalBlock(scope: !2, file: !1, line: 14, column: 9)
+!49 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-functions.move_14_my_struct_copy_2", scope: !50, file: !1, line: 14, type: !11)
+!50 = distinct !DILexicalBlock(scope: !2, file: !1, line: 14, column: 9)

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/dwarf-tests/dwarf-struct-2-modules-build/0x101__M.ll.debug_info.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/dwarf-tests/dwarf-struct-2-modules-build/0x101__M.ll.debug_info.expected
@@ -50,9 +50,16 @@ entry:
   %insert_3 = insertvalue %struct.M__MyStruct %insert_2, i8 %fv.3, 3
   %insert_4 = insertvalue %struct.M__MyStruct %insert_3, %struct.M__Combined %fv.4, 4
   store %struct.M__MyStruct %insert_4, ptr %local_9, align 8
-  %retval = load %struct.M__MyStruct, ptr %local_9, align 8
-  ret %struct.M__MyStruct %retval
+  %retval = load %struct.M__MyStruct, ptr %local_9, align 8, !dbg !37
+  call void @llvm.dbg.declare(metadata ptr %local_9, metadata !38, metadata !DIExpression()), !dbg !37
+  call void @llvm.dbg.declare(metadata ptr %local_9, metadata !40, metadata !DIExpression()), !dbg !37
+  ret %struct.M__MyStruct %retval, !dbg !37
 }
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
+
+attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!0}
 !fun_1 = !{!2, !5, !6, !7}
@@ -63,7 +70,7 @@ entry:
 
 !0 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !1, producer: "move-mv-llvm-compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, sysroot: "/")
 !1 = !DIFile(filename: "dwarf-struct-2-modules.move", directory: "/move/solana/move-mv-llvm-compiler/tests/dwarf-tests")
-!2 = distinct !DISubprogram(name: "fun_1", linkageName: "fun_1", scope: !1, file: !1, line: 33, type: !3, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !0)
+!2 = distinct !DISubprogram(name: "fun_1", linkageName: "fun_1", scope: !1, file: !1, line: 33, type: !3, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !0, retainedNodes: !4)
 !3 = !DISubroutineType(types: !4)
 !4 = !{}
 !5 = distinct !DILexicalBlock(scope: !2, file: !1, line: 5)
@@ -98,3 +105,8 @@ entry:
 !34 = !DIDerivedType(tag: DW_TAG_member, name: "field4_u8", scope: !28, file: !1, line: 22, baseType: !35, size: 8, align: 8, offset: 48)
 !35 = !DIBasicType(name: "u8", size: 8)
 !36 = !DIDerivedType(tag: DW_TAG_member, name: "field6_combined", scope: !28, file: !1, line: 23, baseType: !21, size: 128, align: 64, offset: 56)
+!37 = !DILocation(line: 46, column: 9, scope: !2)
+!38 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-struct-2-modules.move_46_my_struct_copy", scope: !39, file: !1, line: 46, type: !27)
+!39 = distinct !DILexicalBlock(scope: !2, file: !1, line: 46, column: 9)
+!40 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-struct-2-modules.move_46_my_struct_copy", scope: !41, file: !1, line: 46, type: !27)
+!41 = distinct !DILexicalBlock(scope: !2, file: !1, line: 46, column: 9)

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/dwarf-tests/dwarf-struct-2-modules-build/0x201__M.ll.debug_info.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/dwarf-tests/dwarf-struct-2-modules-build/0x201__M.ll.debug_info.expected
@@ -24,11 +24,18 @@ entry:
   %insert_0 = insertvalue %struct.M__MyStruct_2 undef, i32 %fv.0, 0
   %insert_1 = insertvalue %struct.M__MyStruct_2 %insert_0, %struct.M__MyStruct %fv.1, 1
   store %struct.M__MyStruct_2 %insert_1, ptr %local_2, align 8
-  %retval1 = load %struct.M__MyStruct_2, ptr %local_2, align 8
-  ret %struct.M__MyStruct_2 %retval1
+  %retval1 = load %struct.M__MyStruct_2, ptr %local_2, align 8, !dbg !40
+  call void @llvm.dbg.declare(metadata ptr %local_2, metadata !41, metadata !DIExpression()), !dbg !40
+  call void @llvm.dbg.declare(metadata ptr %local_2, metadata !43, metadata !DIExpression()), !dbg !40
+  ret %struct.M__MyStruct_2 %retval1, !dbg !40
 }
 
 declare %struct.M__MyStruct @"0000000000000101_M_fun_1_AcLtMspYikxikv"()
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
+
+attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!0}
 !fun_2 = !{!2, !5, !6, !7}
@@ -36,7 +43,7 @@ declare %struct.M__MyStruct @"0000000000000101_M_fun_1_AcLtMspYikxikv"()
 
 !0 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !1, producer: "move-mv-llvm-compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, sysroot: "/")
 !1 = !DIFile(filename: "dwarf-struct-2-modules.move", directory: "/move/solana/move-mv-llvm-compiler/tests/dwarf-tests")
-!2 = distinct !DISubprogram(name: "fun_2", linkageName: "fun_2", scope: !1, file: !1, line: 7, type: !3, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !0)
+!2 = distinct !DISubprogram(name: "fun_2", linkageName: "fun_2", scope: !1, file: !1, line: 7, type: !3, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !0, retainedNodes: !4)
 !3 = !DISubroutineType(types: !4)
 !4 = !{}
 !5 = distinct !DILexicalBlock(scope: !2, file: !1, line: 5)
@@ -74,3 +81,8 @@ declare %struct.M__MyStruct @"0000000000000101_M_fun_1_AcLtMspYikxikv"()
 !37 = !DIDerivedType(tag: DW_TAG_member, name: "field_u64", scope: !35, file: !1, line: 29, baseType: !38, size: 64, align: 64)
 !38 = !DIBasicType(name: "u64", size: 64)
 !39 = !DILocation(line: 11, column: 39, scope: !2)
+!40 = !DILocation(line: 14, column: 9, scope: !2)
+!41 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-struct-2-modules.move_14_my_struct_copy_2", scope: !42, file: !1, line: 14, type: !9)
+!42 = distinct !DILexicalBlock(scope: !2, file: !1, line: 14, column: 9)
+!43 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-struct-2-modules.move_14_my_struct_copy_2", scope: !44, file: !1, line: 14, type: !9)
+!44 = distinct !DILexicalBlock(scope: !2, file: !1, line: 14, column: 9)

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/dwarf-tests/dwarf-struct-build/0x100__M.ll.debug_info.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/dwarf-tests/dwarf-struct-build/0x100__M.ll.debug_info.expected
@@ -50,9 +50,16 @@ entry:
   %insert_3 = insertvalue %struct.M__MyStruct %insert_2, i8 %fv.3, 3
   %insert_4 = insertvalue %struct.M__MyStruct %insert_3, %struct.M__Combined %fv.4, 4
   store %struct.M__MyStruct %insert_4, ptr %local_9, align 8
-  %retval = load %struct.M__MyStruct, ptr %local_9, align 8
-  ret %struct.M__MyStruct %retval
+  %retval = load %struct.M__MyStruct, ptr %local_9, align 8, !dbg !37
+  call void @llvm.dbg.declare(metadata ptr %local_9, metadata !38, metadata !DIExpression()), !dbg !37
+  call void @llvm.dbg.declare(metadata ptr %local_9, metadata !40, metadata !DIExpression()), !dbg !37
+  ret %struct.M__MyStruct %retval, !dbg !37
 }
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
+
+attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!0}
 !fun_1 = !{!2, !5, !6, !7}
@@ -63,7 +70,7 @@ entry:
 
 !0 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !1, producer: "move-mv-llvm-compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, sysroot: "/")
 !1 = !DIFile(filename: "dwarf-struct.move", directory: "/move/solana/move-mv-llvm-compiler/tests/dwarf-tests")
-!2 = distinct !DISubprogram(name: "fun_1", linkageName: "fun_1", scope: !1, file: !1, line: 16, type: !3, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !0)
+!2 = distinct !DISubprogram(name: "fun_1", linkageName: "fun_1", scope: !1, file: !1, line: 16, type: !3, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !0, retainedNodes: !4)
 !3 = !DISubroutineType(types: !4)
 !4 = !{}
 !5 = distinct !DILexicalBlock(scope: !2, file: !1, line: 5)
@@ -98,3 +105,8 @@ entry:
 !34 = !DIDerivedType(tag: DW_TAG_member, name: "field4_u8", scope: !28, file: !1, line: 5, baseType: !35, size: 8, align: 8, offset: 48)
 !35 = !DIBasicType(name: "u8", size: 8)
 !36 = !DIDerivedType(tag: DW_TAG_member, name: "field6_combined", scope: !28, file: !1, line: 6, baseType: !21, size: 128, align: 64, offset: 56)
+!37 = !DILocation(line: 29, column: 9, scope: !2)
+!38 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-struct.move_29_my_struct_copy", scope: !39, file: !1, line: 29, type: !27)
+!39 = distinct !DILexicalBlock(scope: !2, file: !1, line: 29, column: 9)
+!40 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-struct.move_29_my_struct_copy", scope: !41, file: !1, line: 29, type: !27)
+!41 = distinct !DILexicalBlock(scope: !2, file: !1, line: 29, column: 9)

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/dwarf-tests/dwarf-vector-build/0x101__vector.ll.debug_info.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/dwarf-tests/dwarf-vector-build/0x101__vector.ll.debug_info.expected
@@ -176,8 +176,10 @@ entry:
   store { ptr, i64, i64 } %load_store_tmp1, ptr %local_5, align 8, !dbg !78
   call void @llvm.dbg.declare(metadata ptr %local_1, metadata !79, metadata !DIExpression()), !dbg !78
   call void @llvm.dbg.declare(metadata ptr %local_5, metadata !81, metadata !DIExpression()), !dbg !78
-  %retval2 = load { ptr, i64, i64 }, ptr %local_5, align 8
-  ret { ptr, i64, i64 } %retval2
+  %retval2 = load { ptr, i64, i64 }, ptr %local_5, align 8, !dbg !78
+  call void @llvm.dbg.declare(metadata ptr %local_5, metadata !83, metadata !DIExpression()), !dbg !78
+  call void @llvm.dbg.declare(metadata ptr %local_5, metadata !85, metadata !DIExpression()), !dbg !78
+  ret { ptr, i64, i64 } %retval2, !dbg !78
 }
 
 define private { ptr, i64, i64 } @"0000000000000101_vector_singleton_39QxpzcPR6oc9x"(%struct.vector__Bar %e) !dbg !31 {
@@ -191,19 +193,21 @@ entry:
   store %struct.vector__Bar %e, ptr %local_0, align 8
   %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_vector__Bar)
   store { ptr, i64, i64 } %retval, ptr %local_2, align 8
-  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_2, align 8, !dbg !83
-  store { ptr, i64, i64 } %load_store_tmp, ptr %local_1, align 8, !dbg !83
-  call void @llvm.dbg.declare(metadata ptr %local_2, metadata !84, metadata !DIExpression()), !dbg !83
-  call void @llvm.dbg.declare(metadata ptr %local_1, metadata !86, metadata !DIExpression()), !dbg !83
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_2, align 8, !dbg !87
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_1, align 8, !dbg !87
+  call void @llvm.dbg.declare(metadata ptr %local_2, metadata !88, metadata !DIExpression()), !dbg !87
+  call void @llvm.dbg.declare(metadata ptr %local_1, metadata !90, metadata !DIExpression()), !dbg !87
   store ptr %local_1, ptr %local_3, align 8
   %loaded_alloca = load ptr, ptr %local_3, align 8
   call void @move_native_vector_push_back(ptr @__move_rttydesc_vector__Bar, ptr %loaded_alloca, ptr %local_0)
-  %load_store_tmp1 = load { ptr, i64, i64 }, ptr %local_1, align 8, !dbg !88
-  store { ptr, i64, i64 } %load_store_tmp1, ptr %local_5, align 8, !dbg !88
-  call void @llvm.dbg.declare(metadata ptr %local_1, metadata !89, metadata !DIExpression()), !dbg !88
-  call void @llvm.dbg.declare(metadata ptr %local_5, metadata !91, metadata !DIExpression()), !dbg !88
-  %retval2 = load { ptr, i64, i64 }, ptr %local_5, align 8
-  ret { ptr, i64, i64 } %retval2
+  %load_store_tmp1 = load { ptr, i64, i64 }, ptr %local_1, align 8, !dbg !92
+  store { ptr, i64, i64 } %load_store_tmp1, ptr %local_5, align 8, !dbg !92
+  call void @llvm.dbg.declare(metadata ptr %local_1, metadata !93, metadata !DIExpression()), !dbg !92
+  call void @llvm.dbg.declare(metadata ptr %local_5, metadata !95, metadata !DIExpression()), !dbg !92
+  %retval2 = load { ptr, i64, i64 }, ptr %local_5, align 8, !dbg !92
+  call void @llvm.dbg.declare(metadata ptr %local_5, metadata !97, metadata !DIExpression()), !dbg !92
+  call void @llvm.dbg.declare(metadata ptr %local_5, metadata !99, metadata !DIExpression()), !dbg !92
+  ret { ptr, i64, i64 } %retval2, !dbg !92
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
@@ -306,13 +310,21 @@ attributes #1 = { cold noreturn }
 !80 = distinct !DILexicalBlock(scope: !25, file: !1, line: 15, column: 9)
 !81 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-vector.move_15_v", scope: !82, file: !1, line: 15, type: !49)
 !82 = distinct !DILexicalBlock(scope: !25, file: !1, line: 15, column: 9)
-!83 = !DILocation(line: 13, column: 13, scope: !31)
-!84 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-vector.move_13_v", scope: !85, file: !1, line: 13, type: !49)
-!85 = distinct !DILexicalBlock(scope: !31, file: !1, line: 13, column: 13)
-!86 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-vector.move_13_v", scope: !87, file: !1, line: 13, type: !49)
-!87 = distinct !DILexicalBlock(scope: !31, file: !1, line: 13, column: 13)
-!88 = !DILocation(line: 15, column: 9, scope: !31)
-!89 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-vector.move_15_v", scope: !90, file: !1, line: 15, type: !49)
-!90 = distinct !DILexicalBlock(scope: !31, file: !1, line: 15, column: 9)
-!91 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-vector.move_15_v", scope: !92, file: !1, line: 15, type: !49)
-!92 = distinct !DILexicalBlock(scope: !31, file: !1, line: 15, column: 9)
+!83 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-vector.move_15_v", scope: !84, file: !1, line: 15, type: !49)
+!84 = distinct !DILexicalBlock(scope: !25, file: !1, line: 15, column: 9)
+!85 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-vector.move_15_v", scope: !86, file: !1, line: 15, type: !49)
+!86 = distinct !DILexicalBlock(scope: !25, file: !1, line: 15, column: 9)
+!87 = !DILocation(line: 13, column: 13, scope: !31)
+!88 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-vector.move_13_v", scope: !89, file: !1, line: 13, type: !49)
+!89 = distinct !DILexicalBlock(scope: !31, file: !1, line: 13, column: 13)
+!90 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-vector.move_13_v", scope: !91, file: !1, line: 13, type: !49)
+!91 = distinct !DILexicalBlock(scope: !31, file: !1, line: 13, column: 13)
+!92 = !DILocation(line: 15, column: 9, scope: !31)
+!93 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-vector.move_15_v", scope: !94, file: !1, line: 15, type: !49)
+!94 = distinct !DILexicalBlock(scope: !31, file: !1, line: 15, column: 9)
+!95 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-vector.move_15_v", scope: !96, file: !1, line: 15, type: !49)
+!96 = distinct !DILexicalBlock(scope: !31, file: !1, line: 15, column: 9)
+!97 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-vector.move_15_v", scope: !98, file: !1, line: 15, type: !49)
+!98 = distinct !DILexicalBlock(scope: !31, file: !1, line: 15, column: 9)
+!99 = !DILocalVariable(name: "load_store_tests/dwarf-tests/dwarf-vector.move_15_v", scope: !100, file: !1, line: 15, type: !49)
+!100 = distinct !DILexicalBlock(scope: !31, file: !1, line: 15, column: 9)

--- a/external-crates/move/solana/move-to-solana/src/stackless/llvm.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/llvm.rs
@@ -747,10 +747,11 @@ impl Builder {
         }
     }
 
-    pub fn load_return(&self, ty: Type, val: Alloca) {
+    pub fn load_return(&self, ty: Type, val: Alloca) -> (*mut LLVMValue, *mut LLVMValue) {
         unsafe {
             let tmp_reg = LLVMBuildLoad2(self.0, ty.0, val.0, "retval".cstr());
-            LLVMBuildRet(self.0, tmp_reg);
+            let ret_val = LLVMBuildRet(self.0, tmp_reg);
+            (tmp_reg, ret_val)
         }
     }
 

--- a/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
@@ -507,7 +507,10 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                     let idx = vals[0];
                     let llval = self.locals[idx].llval;
                     let llty = self.locals[idx].llty;
-                    builder.load_return(llty, llval);
+                    let mty = &self.locals[idx].mty;
+                    let (tmp, ret_val) = builder.load_return(llty, llval);
+                    // Dwarf for tracing return value can be done similar to tracing local variables
+                    instr_dbg.create_load_store(tmp, ret_val, mty, llty, llval, llval);
                 }
                 _ => {
                     // Multiple return values are wrapped in a struct.


### PR DESCRIPTION
Adding support for important feature of debugger: tracing function return value.
Since api in dwarf.rs is already well developed, no new function is needed - just use load_store existing mechanism.

```
sol@dev-equinix-new-york-2:~/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests:032024--dwarf-tracing-retval *%$ cargo test --test dwarf-tests
    Finished test [unoptimized + debuginfo] target(s) in 0.45s
     Running tests/dwarf-tests.rs (/home/sol/work/git/sui-solana-032024/external-crates/move/target/debug/deps/dwarf_tests-e24091a10001f082)

running 5 tests
    Finished dev [unoptimized + debuginfo] target(s) in 0.29s
    Finished dev [unoptimized + debuginfo] target(s) in 0.18s
test run_test::dwarf-struct.move           ... ok
test run_test::dwarf-struct-2-modules.move ... ok
test run_test::dwarf-functions.move        ... ok
test run_test::dwarf-vector.move           ... ok
test run_test::basic-coin.move             ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.59s


```