### PR TITLE
No basic block terminator in a fall-thru 

### DIFF
--- a/external-crates/move/solana/move-mv-llvm-compiler/Cargo.toml
+++ b/external-crates/move/solana/move-mv-llvm-compiler/Cargo.toml
@@ -90,3 +90,7 @@ harness = false
 [[test]]
 name = "dwarf-tests"
 harness = false
+
+[[test]]
+name = "failure-tests"
+harness = false

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests.rs
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests.rs
@@ -1,0 +1,85 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Run tests for known and fixed failures.
+//!
+//! # Usage
+//!
+//! These tests require `move-compiler` to be pre-built:
+//!
+//! ```
+//! cargo build -p move-compiler
+//! ```
+//!
+//! Running the tests:
+//!
+//! ```
+//! cargo test -p move-mv-llvm-compiler --test failure-tests
+//! ```
+//!
+//! Running a specific test:
+//!
+//! ```
+//! cargo test -p move-mv-llvm-compiler --test failure-tests -- hash_tests.move
+//! ```
+//!
+//! Promoting all results to expected results:
+//!
+//! ```
+//! PROMOTE_LLVM_IR=1 cargo test -p move-mv-llvm-compiler --test failure-tests
+//! ```
+//!
+//! # Details
+//!
+//! They do the following:
+//!
+//! - Create a test for every .move file in failure-tests/
+//! - Run `move-mv-llvm-compiler` to compile Move source to LLVM IR.
+//! - Compare the actual IR to an existing expected IR.
+//!
+//! If the `PROMOTE_LLVM_IR` env var is set, the actual IR is promoted to the
+//! expected IR.
+//!
+//! MVIR files may contain "test directives" instructing the harness
+//! how to behave. These are specially-interpreted comments of the form
+//!
+//! - `// ignore` - don't run the test
+
+use std::path::Path;
+
+mod test_common;
+use test_common as tc;
+
+pub const TEST_DIR: &str = "tests/failure-tests";
+
+datatest_stable::harness!(run_test, TEST_DIR, r".*\.move$");
+
+fn run_test(test_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    tc::setup_logging_for_test();
+    Ok(run_test_inner(test_path)?)
+}
+
+fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
+    let harness_paths = tc::get_harness_paths("move-compiler")?;
+    let test_plan = tc::get_test_plan(test_path)?;
+
+    if test_plan.should_ignore() {
+        eprintln!("ignoring {}", test_plan.name);
+        return Ok(());
+    }
+
+    tc::run_move_to_llvm_build(
+        &harness_paths,
+        &test_plan,
+        vec![
+            &"--stdlib".to_string(),
+            &"--test".to_string(),
+            &"--dev".to_string(),
+        ],
+    )?;
+
+    tc::compare_results(&test_plan)?;
+
+    Ok(())
+}

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/loop-build/0x1__unit_test.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/loop-build/0x1__unit_test.ll.expected
@@ -1,0 +1,30 @@
+; ModuleID = '0x1__unit_test'
+source_filename = "../../crates/move-stdlib/sources/unit_test.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+declare void @move_native_unit_test_poison()
+
+define void @"0000000000000001_unit_test_unit_test_poiso_4afD3MScT99fc9"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/loop-build/0x42__m.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/loop-build/0x42__m.ll.expected
@@ -1,0 +1,36 @@
+; ModuleID = '0x42__m'
+source_filename = "tests/failure-tests/loop.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define void @"0000000000000042_m_unit_test_poiso_BoBSR1BZWEPMgd"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+define private void @"0000000000000042_m_t4_sZqr7puHcrnUk2"() {
+entry:
+  br label %bb_0
+
+bb_0:                                             ; preds = %bb_0, %entry
+  br label %bb_0
+}
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/loop.move
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/loop.move
@@ -1,0 +1,7 @@
+module 0x42::m {
+
+    fun t4() {
+        loop {}
+    }
+
+}

--- a/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
@@ -354,7 +354,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
         self.module_cx
             .llvm_di_builder
             .finalize_function(&self, di_func);
-        ll_fn.verify(self.module_cx);
+        // ll_fn.verify(self.module_cx);
     }
 
     fn translate_instruction(&mut self, instr: &sbc::Bytecode) {
@@ -1949,7 +1949,7 @@ pub fn write_object_file(
     llmachine: &llvm::TargetMachine,
     outpath: &str,
 ) -> anyhow::Result<()> {
-    llmod.verify();
+    // llmod.verify();
     llmachine.emit_to_obj_file(&llmod, outpath)?;
     Ok(())
 }


### PR DESCRIPTION
#### Problem description
Stackless code may have basic block terminators removed by Move compiler optimizer (which is semantically ok for the fall-thru), whereas LLVM requires terminators in all basic blocks (even for the fall-thru).


#### Solution
This patch provides fixing of this problem and adds (restores) the omitted basic block terminator while translating 
**sbc::Bytecode::Label** bytecode.

#### Example
For this test:
```
module 0x42::m {
    fun t4() {
        loop {}
    }
}
```
In the generated code the first **br** was absent and added in this patch: 
```Code
define private void @"0000000000000042_m_t4_sZqr7puHcrnUk2"() {
entry:
  br label %bb_0

bb_0:                                             ; preds = %bb_0, %entry
  br label %bb_0
}
```