### PR TITLE
Support naked expected_failure in tests

### DIFF
--- a/external-crates/move/crates/move-stdlib/tests/vector_tests.move
+++ b/external-crates/move/crates/move-stdlib/tests/vector_tests.move
@@ -565,11 +565,8 @@ module std::vector_tests {
         };
     }
 
-    // todo solana
     #[test]
-    //#[expected_failure(vector_error, minor_status = 4, location = Self)]
     #[expected_failure]
-    // #[expected_failure(major_status=18446744073709551615, minor_status=17, location=std::vector)]
     fun size_limit_fail() {
         let v = V::empty();
         let i = 0;

--- a/external-crates/move/crates/move-stdlib/tests/vector_tests.move
+++ b/external-crates/move/crates/move-stdlib/tests/vector_tests.move
@@ -566,8 +566,10 @@ module std::vector_tests {
     }
 
     // todo solana
-    //#[test]
+    #[test]
     //#[expected_failure(vector_error, minor_status = 4, location = Self)]
+    #[expected_failure]
+    // #[expected_failure(major_status=18446744073709551615, minor_status=17, location=std::vector)]
     fun size_limit_fail() {
         let v = V::empty();
         let i = 0;

--- a/external-crates/move/crates/move-unit-test/src/test_runner.rs
+++ b/external-crates/move/crates/move-unit-test/src/test_runner.rs
@@ -660,6 +660,12 @@ impl SharedTestingConfig {
                     output.pass(function_name);
                     stats.test_success(test_run_info(), test_plan);
                 }
+                // Support tests with naked expected_failure, for example size_limit_fail in vector_tests.move
+                (Some(
+                    ExpectedFailure::Expected), move_to_solana::runner::ExitReason::Failure) => {
+                    output.pass(function_name);
+                    stats.test_success(test_run_info(), test_plan);
+                }
                 (_exp, _reason) => {
                     output.fail(function_name);
                     stats.test_failure(

--- a/external-crates/move/crates/move-unit-test/tests/test_sources/timeout.solana.exp
+++ b/external-crates/move/crates/move-unit-test/tests/test_sources/timeout.solana.exp
@@ -3,7 +3,7 @@ Running Move unit tests
 [ FAIL    ] 0x1::M::no_timeout_fail
 [ PASS    ] 0x1::M::no_timeout_while_loop
 [ FAIL    ] 0x1::M::timeout_fail
-[ FAIL    ] 0x1::M::timeout_fail_with_expected_failure
+[ PASS    ] 0x1::M::timeout_fail_with_expected_failure
 
 Test failures:
 
@@ -21,12 +21,4 @@ Failures in 0x1::M:
 │ Err(ExceededMaxInstructions(110))
 └──────────────────
 
-
-┌── timeout_fail_with_expected_failure ──────
-│ Failed to run a program on Solana VM.
-│ 
-│ 
-│ Err(ExceededMaxInstructions(112))
-└──────────────────
-
-Test result: FAILED. Total tests: 5; passed: 2; failed: 3
+Test result: FAILED. Total tests: 5; passed: 3; failed: 2


### PR DESCRIPTION
Adding a missing case in processing of `expected_failure` with no error code.
Example:

```Move
    #[test]
    #[expected_failure]
    fun size_limit_fail() {
        let v = V::empty();
        let i = 0;
        // Limit is currently 1024 * 1024
        let max_len = 1024 * 1024 + 1;

        while (i < max_len) {
            V::push_back(&mut v, i);
            i = i + 1;
        };
    }
```

This fixes tests:
- **size_limit_fail** in **vector_tests**,
- **timeout_fail_with_expected_failure** in **move_unit_test**.