### PR TITLE
Support expected_failure with parameters

### DIFF
--- a/external-crates/move/crates/move-stdlib/tests/vector_tests.move
+++ b/external-crates/move/crates/move-stdlib/tests/vector_tests.move
@@ -6,6 +6,10 @@ module std::vector_tests {
     struct Droppable has drop {}
     struct NotDroppable {}
 
+    // defined in vm_status.rs
+    const MEMORY_LIMIT_EXCEEDED: u64 = 4028;
+    const UNKNOWN_STATUS: u64 = 18446744073709551615;
+
     #[test]
     fun test_singleton_contains() {
         assert!(*V::borrow(&V::singleton(0), 0) == 0, 0);
@@ -566,12 +570,12 @@ module std::vector_tests {
     }
 
     #[test]
-    #[expected_failure]
+    #[expected_failure(major_status = MEMORY_LIMIT_EXCEEDED, minor_status = UNKNOWN_STATUS, location=Self)]
     fun size_limit_fail() {
         let v = V::empty();
         let i = 0;
-        // Limit is currently 1024 * 1024
-        let max_len = 1024 * 1024 + 1;
+        // Solana default limit is 1024 * 2
+        let max_len = 1024 * 2 + 1;
 
         while (i < max_len) {
             V::push_back(&mut v, i);

--- a/external-crates/move/crates/move-unit-test/src/test_runner.rs
+++ b/external-crates/move/crates/move-unit-test/src/test_runner.rs
@@ -492,7 +492,9 @@ impl SharedTestingConfig {
         stats
     }
 
+    //
     #[cfg(feature = "solana-backend")]
+    //
     fn exec_module_tests_solana(
         &self,
         test_plan: &ModuleTestPlan,
@@ -659,6 +661,29 @@ impl SharedTestingConfig {
                 | (Some(ExpectedFailure::Expected), move_to_solana::runner::ExitReason::Abort) => {
                     output.pass(function_name);
                     stats.test_success(test_run_info(), test_plan);
+                }
+                // Support expected failures with known error codes
+                (Some(ExpectedFailure::ExpectedWithError(error)), move_to_solana::runner::ExitReason::Failure) => {
+                    // Processing
+                    // #[expected_failure(major_status = MEMORY_LIMIT_EXCEEDED, minor_status = UNKNOWN_STATUS, location=Self)]
+                    if error.0 == StatusCode::MEMORY_LIMIT_EXCEEDED {
+                        if let (Some(minor_status), return_value) = (error.1, result.return_value) {
+                            if minor_status == return_value {
+                                output.pass(function_name);
+                                stats.test_success(test_run_info(), test_plan);
+                            }
+                        }
+                    } else {
+                        output.fail(function_name);
+                        stats.test_failure(
+                            TestFailure::new(
+                                FailureReason::solana_vm_error(result.log),
+                                test_run_info(),
+                                None,
+                            ),
+                            test_plan,
+                        )
+                    }
                 }
                 // Support tests with naked expected_failure, for example size_limit_fail in vector_tests.move
                 (Some(

--- a/external-crates/move/crates/move-unit-test/src/test_runner.rs
+++ b/external-crates/move/crates/move-unit-test/src/test_runner.rs
@@ -492,9 +492,7 @@ impl SharedTestingConfig {
         stats
     }
 
-    //
     #[cfg(feature = "solana-backend")]
-    //
     fn exec_module_tests_solana(
         &self,
         test_plan: &ModuleTestPlan,


### PR DESCRIPTION
Naked expected_failure sometimes may be not sufficient, since it merely checks that tests failed yet it may fail for unexpected reason.
So, enabling expected_failure with parameters.  

In this PR one only test that uses _naked expected_failure_ is converted to _expected_failure with parameters_, but more tests may be added in own PRs. Very likely, that some tests will require adding specific codes to the processing clause in actual-expected matching.


Note that for this we add to move tests the expected error codes that are returned by Solana VM.
