### PR TITLE
Add heap_size and call_depth flags to gas_budget attributes

### DIFF
--- a/external-crates/move/crates/move-stdlib/tests/bit_vector_tests.move
+++ b/external-crates/move/crates/move-stdlib/tests/bit_vector_tests.move
@@ -53,7 +53,7 @@ module std::bit_vector_tests {
     }
 
     #[test]
-    #[gas_budget(compute_unit_limit=10000000)]
+    #[gas_budget(compute_unit_limit=10000000, heap_size=1000, max_call_depth=10)]
     fun test_set_bit_and_index_basic() {
         test_bitvector_set_unset_of_size(8)
     }


### PR DESCRIPTION
More tests will be added when I wire these to the test case runners.