### PR TITLE
Remove unneeded single-threaded restriction  in move_check_testsuite test

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -55,4 +55,4 @@ jobs:
 
       - name: move-compiler move_check_testsuite tests
         run: |
-          cargo test --manifest-path external-crates/move/Cargo.toml --profile ci -p move-compiler --test move_check_testsuite -- --test-threads=1
+          cargo test --manifest-path external-crates/move/Cargo.toml --profile ci -p move-compiler --test move_check_testsuite


### PR DESCRIPTION
Makes test run about 20 times faster
