### PR TITLE
Enable dwarf for binary (object file when we compile precompiled modules)

### DIFF
--- a/external-crates/move/solana/move-mv-llvm-compiler/src/main.rs
+++ b/external-crates/move/solana/move-mv-llvm-compiler/src/main.rs
@@ -272,7 +272,7 @@ fn main() -> anyhow::Result<()> {
                 &llmod,
                 &entrypoint_generator,
                 &options,
-                mod_src,
+                mod_src.to_string(),
             );
             mod_cx.translate();
 

--- a/external-crates/move/solana/move-to-solana/src/lib.rs
+++ b/external-crates/move/solana/move-to-solana/src/lib.rs
@@ -420,7 +420,7 @@ fn compile(global_env: &GlobalEnv, options: &Options) -> anyhow::Result<()> {
             &llmod,
             &entrypoint_generator,
             options,
-            module_source_path,
+            module_source_path.to_string(),
         );
         mod_cx.translate();
 

--- a/external-crates/move/solana/move-to-solana/src/stackless/dwarf.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/dwarf.rs
@@ -477,6 +477,7 @@ impl<'up> DIBuilder<'up> {
         module: &Module,
         source: &str,
         debug: bool,
+        _binary: bool, // if set debug_info section automatically added to *.o. '_binary' reserved for future processing.
     ) -> DIBuilder<'up> {
         if debug {
             let llmod = module.0;

--- a/external-crates/move/solana/move-to-solana/src/stackless/llvm.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/llvm.rs
@@ -122,8 +122,9 @@ impl Context {
         module: &Module,
         source: &str,
         debug: bool,
+        binary: bool
     ) -> DIBuilder {
-        DIBuilder::new(g_ctx, module, source, debug)
+        DIBuilder::new(g_ctx, module, source, debug, binary)
     }
 
     pub fn get_anonymous_struct_type(&self, field_tys: &[Type]) -> Type {

--- a/external-crates/move/solana/move-to-solana/src/stackless/module_context.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/module_context.rs
@@ -46,7 +46,7 @@ pub struct ModuleContext<'mm: 'up, 'up> {
     pub target_machine: &'up TargetMachine,
     pub options: &'up Options,
     pub rtty_cx: RttyContext<'mm, 'up>,
-    pub source: &'up str,
+    pub source: String,
 }
 
 impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {

--- a/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
@@ -145,16 +145,17 @@ impl<'up> GlobalContext<'up> {
         llmod: &'this llvm::Module,
         entrypoint_generator: &'this EntrypointGenerator<'this, 'up>,
         options: &'this Options,
-        source: &'this str,
+        source: String,
     ) -> ModuleContext<'up, 'this> {
         let Self { env, llvm_cx, .. } = self;
 
         let m_env = env.get_module(id);
         let modname = m_env.llvm_module_name();
-        debug!(target: "dwarf", "Create DWARF for module {:#?} with source {:#?}", modname, source);
         // DIBuilder does not depend on Builder and can be created first
         // Note: if options.bytecode_file_path.is_some() we compile from binary and debug information is already lost, then do not try to retrieve it.
-        let llvm_di_builder = llvm_cx.create_di_builder(self, llmod, source, options.debug && options.bytecode_file_path.is_none());
+        let source = if options.bytecode_file_path.is_some() {options.bytecode_file_path.clone().unwrap()} else {source.to_string()};
+        debug!(target: "dwarf", "Create DWARF for module {:#?} with source {:#?}", modname, source);
+        let llvm_di_builder = llvm_cx.create_di_builder(self, llmod, &source, options.debug, options.bytecode_file_path.is_some());
         let llvm_builder = llvm_cx.create_builder();
         let rtty_cx = RttyContext::new(self.env, &self.llvm_cx, llmod);
         ModuleContext {


### PR DESCRIPTION
Originally dwarf generation expected that compilation is done from the sources.
But our tests (in particularly rbpf) were written as compilation from precompiled Move binaries to Solana binary object.
So we may want to enable dwarf info when -b option is used.
 This patch does this.
 
 Expect debug_info section in .o as something like this when **-g** is set

` > objdump -g /home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/vec-build/modules/1_Test.o`

```
/home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/vec-build/modules/1_Test.o:     file format elf64-little

Contents of the .debug_abbrev section (loaded from /home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/vec-build/modules/1_Test.o):

  Number TAG (0x0)
   1      DW_TAG_compile_unit    [has children]
    DW_AT_producer     DW_FORM_strp
    DW_AT_language     DW_FORM_data2
    DW_AT_name         DW_FORM_strp
    Unknown AT value: 3e02 DW_FORM_strp
    DW_AT_stmt_list    DW_FORM_sec_offset
    DW_AT_comp_dir     DW_FORM_strp
    DW_AT_GNU_pubnames DW_FORM_flag_present
    DW_AT_low_pc       DW_FORM_addr
    DW_AT_high_pc      DW_FORM_data4
    DW_AT value: 0     DW_FORM value: 0
   2      DW_TAG_subprogram    [no children]
    DW_AT_low_pc       DW_FORM_addr
    DW_AT_high_pc      DW_FORM_data4
    DW_AT_frame_base   DW_FORM_exprloc
    DW_AT_linkage_name DW_FORM_strp
    DW_AT_name         DW_FORM_strp
    DW_AT_type         DW_FORM_ref4
    DW_AT value: 0     DW_FORM value: 0
   3      DW_TAG_unspecified_type    [no children]
    DW_AT_name         DW_FORM_strp
    DW_AT value: 0     DW_FORM value: 0

Contents of the .debug_info section (loaded from /home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/vec-build/modules/1_Test.o):

  Compilation Unit @ offset 0x0:
   Length:        0x4b (32-bit)
   Version:       4
   Abbrev Offset: 0x0
   Pointer Size:  8
 <0><b>: Abbrev Number: 1 (DW_TAG_compile_unit)
    <c>   DW_AT_producer    : (indirect string, offset: 0x0): move-mv-llvm-compiler
    <10>   DW_AT_language    : 28       (Rust)
    <12>   DW_AT_name        : (indirect string, offset: 0x0): move-mv-llvm-compiler
    <16>   Unknown AT value: 3e02: (indirect string, offset: 0x0): move-mv-llvm-compiler
    <1a>   DW_AT_stmt_list   : 0x0
    <1e>   DW_AT_comp_dir    : (indirect string, offset: 0x0): move-mv-llvm-compiler
    <22>   DW_AT_GNU_pubnames: 1
    <22>   DW_AT_low_pc      : 0x0
    <2a>   DW_AT_high_pc     : 0x840
 <1><2e>: Abbrev Number: 2 (DW_TAG_subprogram)
    <2f>   DW_AT_low_pc      : 0x0
    <37>   DW_AT_high_pc     : 0x840
    <3b>   DW_AT_frame_base  : 1 byte block: 5a         (DW_OP_reg10 (r10))
    <3d>   DW_AT_linkage_name: (indirect string, offset: 0x0): move-mv-llvm-compiler
    <41>   DW_AT_name        : (indirect string, offset: 0x0): move-mv-llvm-compiler
    <45>   DW_AT_type        : <0x49>
 <1><49>: Abbrev Number: 3 (DW_TAG_unspecified_type)
    <4a>   DW_AT_name        : (indirect string, offset: 0x0): move-mv-llvm-compiler
 <1><4e>: Abbrev Number: 0

Contents of the .debug_str section (loaded from /home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/vec-build/modules/1_Test.o):

  0x00000000 6d6f7665 2d6d762d 6c6c766d 2d636f6d move-mv-llvm-com
  0x00000010 70696c65 7200315f 54657374 2e6d7600 piler.1_Test.mv.
  0x00000020 2f002f68 6f6d652f 736f6c2f 776f726b /./home/sol/work
  0x00000030 2f676974 2f737569 2d736f6c 616e612d /git/sui-solana-
  0x00000040 30333230 32342f65 78746572 6e616c2d 032024/external-
  0x00000050 63726174 65732f6d 6f76652f 736f6c61 crates/move/sola
  0x00000060 6e612f6d 6f76652d 6d762d6c 6c766d2d na/move-mv-llvm-
  0x00000070 636f6d70 696c6572 2f746573 74732f72 compiler/tests/r
  0x00000080 6270662d 74657374 732f7665 632d6275 bpf-tests/vec-bu
  0x00000090 696c642f 6d6f6475 6c657300 74657374 ild/modules.test
  0x000000a0 5f6d6169 6e00756e 73706563 69666965 _main.unspecifie
  0x000000b0 64207479 706500                     d type.

Contents of the .debug_pubnames section (loaded from /home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/vec-build/modules/1_Test.o):

  Length:                              28
  Version:                             2
  Offset into .debug_info section:     0x0
  Size of area in .debug_info section: 79

    Offset      Name
    2e          test_main

Contents of the .debug_pubtypes section (loaded from /home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/vec-build/modules/1_Test.o):

  Length:                              35
  Version:                             2
  Offset into .debug_info section:     0x0
  Size of area in .debug_info section: 79

    Offset      Name
    49          unspecified type

Contents of the .eh_frame section (loaded from /home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/vec-build/modules/1_Test.o):


00000000 00000010 00000000 CIE
  Version:               1
  Augmentation:          "zR"
  Code alignment factor: 8
  Data alignment factor: -4
  Return address column: 11
  Augmentation data:     0c
  DW_CFA_nop
  DW_CFA_nop
  DW_CFA_nop

00000014 00000018 00000018 FDE cie=00000000 pc=00000000..00000840
  DW_CFA_nop
  DW_CFA_nop
  DW_CFA_nop
:

Raw dump of debug contents of section .debug_line (loaded from /home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/vec-build/modules/1_Test.o):

  Offset:                      0x0
  Length:                      62
  DWARF Version:               4
  Prologue Length:             33
  Minimum Instruction Length:  8
  Maximum Ops per Instruction: 1
  Initial value of 'is_stmt':  1
  Line Base:                   -5
  Line Range:                  14
  Opcode Base:                 13

 Opcodes:
  Opcode 1 has 0 args
  Opcode 2 has 1 arg
  Opcode 3 has 1 arg
  Opcode 4 has 1 arg
  Opcode 5 has 1 arg
  Opcode 6 has 0 args
  Opcode 7 has 0 args
  Opcode 8 has 0 args
  Opcode 9 has 1 arg
  Opcode 10 has 0 args
  Opcode 11 has 0 args
  Opcode 12 has 1 arg

 The Directory Table is empty.

 The File Name Table (offset 0x1d):
  Entry Dir     Time    Size    Name
  1     0       0       0       1_Test.mv

 Line Number Statements:
  [0x0000002b]  Extended opcode 2: set Address to 0x0
  [0x00000036]  Special opcode 4: advance Address by 0 to 0x0 and Line by -1 to 0
  [0x00000037]  Set column to 1
  [0x00000039]  Set prologue_end to true
  [0x0000003a]  Advance PC by constant 136 to 0x88
  [0x0000003b]  Special opcode 48: advance Address by 24 to 0xa0 and Line by 1 to 1
  [0x0000003c]  Advance PC by 1952 to 0x840
  [0x0000003f]  Extended opcode 1: End of Sequence


(END)
```


And without **-g** option the same compiled module has `debug_info`section  as short as this:
```
/home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/vec-build/modules/1_Test.o:     file format elf64-little

Contents of the .eh_frame section (loaded from /home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/vec-build/modules/1_Test.o):


00000000 00000010 00000000 CIE
  Version:               1
  Augmentation:          "zR"
  Code alignment factor: 8
  Data alignment factor: -4
  Return address column: 11
  Augmentation data:     0c
  DW_CFA_nop
  DW_CFA_nop
  DW_CFA_nop

00000014 00000018 00000018 FDE cie=00000000 pc=00000000..00000840
  DW_CFA_nop
  DW_CFA_nop
  DW_CFA_nop

```