### PR TITLE
Enhancing compilation process: extending -c compilation to .o generation, also enabling dwarf in -b compilation

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -48,7 +48,7 @@ jobs:
           cargo build --manifest-path external-crates/move/Cargo.toml --profile ci -p move-cli --bin move --features solana-backend
           cargo build --manifest-path external-crates/move/Cargo.toml --profile ci -p move-compiler
           cargo build --manifest-path external-crates/move/Cargo.toml --profile ci -p move-ir-compiler
-          cargo test --manifest-path external-crates/move/Cargo.toml --profile ci -p move-mv-llvm-compiler
+          cargo test --manifest-path external-crates/move/Cargo.toml --profile ci -p move-mv-llvm-compiler -- --test-threads=1
         env:
           LLVM_SYS_170_PREFIX: ${{ env.MOVE_DEV_PATH }}
           PLATFORM_TOOLS_ROOT: ${{ env.PLATFORM_TOOLS_PATH }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -48,7 +48,7 @@ jobs:
           cargo build --manifest-path external-crates/move/Cargo.toml --profile ci -p move-cli --bin move --features solana-backend
           cargo build --manifest-path external-crates/move/Cargo.toml --profile ci -p move-compiler
           cargo build --manifest-path external-crates/move/Cargo.toml --profile ci -p move-ir-compiler
-          cargo test --manifest-path external-crates/move/Cargo.toml --profile ci -p move-mv-llvm-compiler -- --test-threads=1
+          cargo test --manifest-path external-crates/move/Cargo.toml --profile ci -p move-mv-llvm-compiler
         env:
           LLVM_SYS_170_PREFIX: ${{ env.MOVE_DEV_PATH }}
           PLATFORM_TOOLS_ROOT: ${{ env.PLATFORM_TOOLS_PATH }}

--- a/external-crates/move/solana/move-mv-llvm-compiler/src/main.rs
+++ b/external-crates/move/solana/move-mv-llvm-compiler/src/main.rs
@@ -282,19 +282,22 @@ fn main() -> anyhow::Result<()> {
             }
 
             let mut obj_output_file_path = output_file_path.clone();
-            if compilation {
+            if compilation || args.llvm_ir {
+                let mut output_file = output_file_path.to_owned();
                 // If '-c' option is set, then -o is the directory to output the compiled modules,
                 // each module 'mod' will get file name 'mod.ll'
+                if compilation {
                     if output_file_path.ends_with('/') {
                         output_file_path.pop();
                     }
                     let mut out_path = Path::new(&output_file_path).to_path_buf().join(modname);
                     out_path.set_extension(&args.output_file_extension);
-                    let output_file = out_path.to_str().unwrap().to_string();
+                    output_file = out_path.to_str().unwrap().to_string();
                     match fs::create_dir_all(out_path.parent().expect("Should be a path")) {
                         Ok(_) => {}
                         Err(err) => eprintln!("Error creating directory: {}", err),
                     }
+                }
                 if let Some(_module_di) = mod_cx.llvm_di_builder.module_di() {
                     let module_di = mod_cx.llvm_module.0;
                     let output_file = format!("{}.debug_info", output_file);

--- a/external-crates/move/solana/move-mv-llvm-compiler/src/main.rs
+++ b/external-crates/move/solana/move-mv-llvm-compiler/src/main.rs
@@ -272,7 +272,7 @@ fn main() -> anyhow::Result<()> {
                 &llmod,
                 &entrypoint_generator,
                 &options,
-                mod_src,
+                mod_src.to_string(),
             );
             mod_cx.translate();
 

--- a/external-crates/move/solana/move-mv-llvm-compiler/src/main.rs
+++ b/external-crates/move/solana/move-mv-llvm-compiler/src/main.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 use cli::{absolute_existing_file, absolute_new_file, Args};
 use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
 use llvm_sys::prelude::LLVMModuleRef;
-use log::Level;
+use log::{Level, debug};
 use move_binary_format::{
     binary_views::BinaryIndexedView,
     file_format::{CompiledModule, CompiledScript},
@@ -35,9 +35,7 @@ fn main() -> anyhow::Result<()> {
     initialize_logger();
     let args = Args::parse();
 
-    if args.llvm_ir && args.obj {
-        anyhow::bail!("can't output both LLVM IR (-S) and object file (-O)");
-    }
+    debug!(target: "launch_compiler", "args: {:#?}", args);
 
     let compilation = args.compile.is_some();
     let deserialization = args.bytecode_file_path.is_some();

--- a/external-crates/move/solana/move-mv-llvm-compiler/src/main.rs
+++ b/external-crates/move/solana/move-mv-llvm-compiler/src/main.rs
@@ -317,7 +317,7 @@ fn main() -> anyhow::Result<()> {
                 write_object_file(llmod, &llmachine, &obj_output_file_path, &options)?;
                 if entrypoint_generator.has_entries() {
                     let path = Path::new(&obj_output_file_path);
-                    if !path.exists() {
+                    if !compilation || !path.exists() {
                         entrypoint_generator.write_object_file(path.to_path_buf().parent().unwrap())?;
                     }
                 }

--- a/external-crates/move/solana/move-mv-llvm-compiler/src/main.rs
+++ b/external-crates/move/solana/move-mv-llvm-compiler/src/main.rs
@@ -29,7 +29,7 @@ use move_model::{
 };
 
 use package::build_dependency;
-use std::{fs, io::Write, path::Path};
+use std::{fs, io::Write, path::{Path, PathBuf}};
 
 fn main() -> anyhow::Result<()> {
     initialize_logger();
@@ -324,9 +324,12 @@ fn main() -> anyhow::Result<()> {
                 }
             }
         } // for
-        if compilation || args.llvm_ir {
+        if compilation {
             if entrypoint_generator.has_entries() {
-                let path = Path::new(&output_file_path);
+                let mut entrypoint_name = entrypoint_generator.llvm_module.get_module_id();
+                entrypoint_name = format!("{}.o", entrypoint_name);
+                let mut path = PathBuf::from(output_file_path); // output_file_path is building directory in case of '-c' compilation
+                path.push(entrypoint_name);
                 entrypoint_generator.write_object_file(path.to_path_buf().parent().unwrap())?;
             }
         }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests.rs
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests.rs
@@ -76,6 +76,7 @@ fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
             &"--stdlib".to_string(),
             &"--test".to_string(),
             &"--dev".to_string(),
+            &"-O".to_string(),
         ],
     )?;
 

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/ir-tests.rs
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/ir-tests.rs
@@ -187,7 +187,7 @@ fn compile_mvir_to_mvbc(
     let mut cmd = Command::new(harness_paths.dep.to_str().expect("PathBuf"));
     cmd.arg(test_plan.mvir_file.to_str().expect("PathBuf"));
 
-    debug!("cmd: {:#?}", cmd);
+    debug!(target: "launch_compiler", "cmd: {:#?}", cmd);
 
     let output = cmd.output()?;
     if !output.status.success() {
@@ -217,7 +217,7 @@ fn compile_mvbc_to_llvmir(
     cmd.arg(test_plan.llir_file.to_str().expect("PathBuf"));
     cmd.arg("-S");
 
-    debug!("cmd: {:#?}", cmd);
+    debug!(target: "launch_compiler", "cmd: {:#?}", cmd);
 
     let output = cmd.output().context("run move-mv-llvm-compiler failed")?;
     if !output.status.success() {

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/ir-tests.rs
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/ir-tests.rs
@@ -48,6 +48,7 @@
 //! - `// ignore` - don't run the test
 
 use anyhow::Context;
+use log::debug;
 use similar::{ChangeTag, TextDiff};
 use std::{
     path::{Path, PathBuf},
@@ -186,6 +187,8 @@ fn compile_mvir_to_mvbc(
     let mut cmd = Command::new(harness_paths.dep.to_str().expect("PathBuf"));
     cmd.arg(test_plan.mvir_file.to_str().expect("PathBuf"));
 
+    debug!("cmd: {:#?}", cmd);
+
     let output = cmd.output()?;
     if !output.status.success() {
         anyhow::bail!(
@@ -213,6 +216,8 @@ fn compile_mvbc_to_llvmir(
     cmd.arg("-o");
     cmd.arg(test_plan.llir_file.to_str().expect("PathBuf"));
     cmd.arg("-S");
+
+    debug!("cmd: {:#?}", cmd);
 
     let output = cmd.output().context("run move-mv-llvm-compiler failed")?;
     if !output.status.success() {

--- a/external-crates/move/solana/move-to-solana/src/lib.rs
+++ b/external-crates/move/solana/move-to-solana/src/lib.rs
@@ -420,7 +420,7 @@ fn compile(global_env: &GlobalEnv, options: &Options) -> anyhow::Result<()> {
             &llmod,
             &entrypoint_generator,
             options,
-            module_source_path,
+            module_source_path.to_string(),
         );
         mod_cx.translate();
 

--- a/external-crates/move/solana/move-to-solana/src/options.rs
+++ b/external-crates/move/solana/move-to-solana/src/options.rs
@@ -4,7 +4,7 @@
 
 use clap::Parser;
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, Clone)]
 #[clap(author, version, about)]
 pub struct Options {
     /// Directories where to lookup dependencies.

--- a/external-crates/move/solana/move-to-solana/src/stackless/dwarf.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/dwarf.rs
@@ -1120,7 +1120,7 @@ impl<'up> DIBuilder<'up> {
                 std::ptr::null(), /* *const i8 */
                 0,                /* usize */
                 LLVMDWARFEmissionKind::LLVMDWARFEmissionKindFull,
-                0,         /* u32 */
+                0,         /* Maybe set to DWARF version 4 */
                 0,         /* i32 */
                 0,         /* i32 */
                 slash_ptr, /* *const i8 */

--- a/external-crates/move/solana/move-to-solana/src/stackless/dwarf.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/dwarf.rs
@@ -477,6 +477,7 @@ impl<'up> DIBuilder<'up> {
         module: &Module,
         source: &str,
         debug: bool,
+        _binary: bool, // if set debug_info section automatically added to *.o. '_binary' reserved for future processing.
     ) -> DIBuilder<'up> {
         if debug {
             let llmod = module.0;

--- a/external-crates/move/solana/move-to-solana/src/stackless/llvm.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/llvm.rs
@@ -122,8 +122,9 @@ impl Context {
         module: &Module,
         source: &str,
         debug: bool,
+        binary: bool
     ) -> DIBuilder {
-        DIBuilder::new(g_ctx, module, source, debug)
+        DIBuilder::new(g_ctx, module, source, debug, binary)
     }
 
     pub fn get_anonymous_struct_type(&self, field_tys: &[Type]) -> Type {

--- a/external-crates/move/solana/move-to-solana/src/stackless/module_context.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/module_context.rs
@@ -46,7 +46,7 @@ pub struct ModuleContext<'mm: 'up, 'up> {
     pub target_machine: &'up TargetMachine,
     pub options: &'up Options,
     pub rtty_cx: RttyContext<'mm, 'up>,
-    pub source: &'up str,
+    pub source: String,
 }
 
 impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {

--- a/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
@@ -145,16 +145,17 @@ impl<'up> GlobalContext<'up> {
         llmod: &'this llvm::Module,
         entrypoint_generator: &'this EntrypointGenerator<'this, 'up>,
         options: &'this Options,
-        source: &'this str,
+        source: String,
     ) -> ModuleContext<'up, 'this> {
         let Self { env, llvm_cx, .. } = self;
 
         let m_env = env.get_module(id);
         let modname = m_env.llvm_module_name();
-        debug!(target: "dwarf", "Create DWARF for module {:#?} with source {:#?}", modname, source);
         // DIBuilder does not depend on Builder and can be created first
         // Note: if options.bytecode_file_path.is_some() we compile from binary and debug information is already lost, then do not try to retrieve it.
-        let llvm_di_builder = llvm_cx.create_di_builder(self, llmod, source, options.debug && options.bytecode_file_path.is_none());
+        let source = if options.bytecode_file_path.is_some() {options.bytecode_file_path.clone().unwrap()} else {source.to_string()};
+        debug!(target: "dwarf", "Create DWARF for module {:#?} with source {:#?}", modname, source);
+        let llvm_di_builder = llvm_cx.create_di_builder(self, llmod, &source, options.debug, options.bytecode_file_path.is_some());
         let llvm_builder = llvm_cx.create_builder();
         let rtty_cx = RttyContext::new(self.env, &self.llvm_cx, llmod);
         ModuleContext {


### PR DESCRIPTION
This PR adds two new abilities to solana-move compiler:
- Option **-g** will generate debug for **.o** object. Before this PR **-g** worked only in combination with **-c** option and was disabled for **-O** option.
- Option **-O** can now work in combination with **-c**, in this case the source in **.move** will be compiled to both: **.ll** and **.o** files. Before this PR compilation with **-c** was generating only **.ll** file.