### PR TITLE
Add utils to generate instruction_data based on name

### DIFF
--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -435,6 +435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "binascii"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,6 +2238,14 @@ checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+]
+
+[[package]]
+name = "input_json"
+version = "1.0.0"
+dependencies = [
+ "binascii",
+ "clap 3.2.23",
 ]
 
 [[package]]

--- a/external-crates/move/solana/util/Cargo.toml
+++ b/external-crates/move/solana/util/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "input_json"
+version = "1.0.0"
+edition = "2021"
+
+[[bin]]
+name = "generate_input_json"
+path = "src/generate_input_json.rs"
+
+[dependencies]
+binascii = "0.1"
+clap = { version = "3.1.8", features = ["derive"] }

--- a/external-crates/move/solana/util/src/generate_input_json.rs
+++ b/external-crates/move/solana/util/src/generate_input_json.rs
@@ -1,0 +1,50 @@
+#[cfg(test)]
+use binascii::{b32encode, b32decode};
+
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[clap(author, version, about)]
+pub struct Args {
+    /// Entry function name
+    #[clap(short = 'f', long = "func-name")]
+    pub entry_function_name: String,
+    // Remaining arguments that we want to serialize as bytes
+    #[clap(short = 's', long = "args", default_value = "")]
+    pub argstring: String,
+}
+
+fn print_as_bytes(data : &str) -> Vec<u8> {
+    let length = data.len();
+    let input = &data[..length].as_bytes();
+    input.to_vec()
+}
+
+#[test]
+fn test_encode_decode() {
+    let data : &str = "counter__owner";
+    let input = &data[..data.len()].as_bytes();
+    let mut output = [0u8; 500];
+    let mut dec_out = [0u8; 200];
+    let encoded_output = b32encode(&input, &mut output).ok().unwrap();
+    let decoded_output = b32decode(&encoded_output, &mut dec_out).ok().unwrap();
+    assert_eq!(input, &decoded_output);
+}
+
+#[test]
+fn test_print_as_bytes() {
+    const ENCODED_DATA : [u8; 11] = [104, 101, 108, 108, 111, 95, 95, 109, 97, 105, 110];
+    let b = print_as_bytes("hello__main");
+    assert_eq!(b.len(), ENCODED_DATA.len());
+    assert_eq!(&ENCODED_DATA, &b[..ENCODED_DATA.len()]);
+}
+
+pub fn main() {
+    let args = Args::parse();
+    let mut b = print_as_bytes(args.entry_function_name.as_str());
+    let mut blen = b.len().to_le_bytes().to_vec();
+    println!("As bytes: {:?}", b.clone());
+    println!("len: {:?}", blen.clone());
+    blen.append(&mut b);
+    println!("\"instruction_data\": {:?}", blen);
+}


### PR DESCRIPTION
Towards #55

We'll keep improving it, but for now this at least prints the bytes that we need to populate instruction_data

Test: `cargo run -- -f counter__owner`
As bytes: [99, 111, 117, 110, 116, 101, 114, 95, 95, 111, 119, 110, 101, 114]
len: [14, 0, 0, 0, 0, 0, 0, 0]
"instruction_data": [14, 0, 0, 0, 0, 0, 0, 0, 99, 111, 117, 110, 116, 101, 114, 95, 95, 111, 119, 110, 101, 114]