### PR TITLE
Adding std::hash::sha2_256 test to rbpf

### DIFF
--- a/external-crates/move/crates/move-stackless-bytecode/src/stackless_bytecode.rs
+++ b/external-crates/move/crates/move-stackless-bytecode/src/stackless_bytecode.rs
@@ -104,6 +104,18 @@ impl From<&u256::U256> for Constant {
         Constant::U256(U256::from(n))
     }
 }
+impl From<&Vec<u8>> for Constant {
+    fn from(v: &Vec<u8>) -> Constant {
+        Constant::ByteArray(v.clone())
+    }
+}
+
+pub fn transform_bytearray_to_vec(val_vec: &[Constant]) -> Option<&Vec<u8>> {
+    if let Some(Constant::ByteArray(ref vec)) = val_vec.first() {
+        return Some(vec);
+    }
+    None
+}
 
 /// An operation -- target of a call. This contains user functions, builtin functions, and
 /// operators.

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/Move.toml
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "drand-call"
+version = "1.0.0"
+
+[addresses]
+# drand = "0xba31"
+hello = "0xba31"
+
+[dependencies]
+Games = { local = "../../../../../../../sui_programmability/examples/games" }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/Move.toml
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/Move.toml
@@ -3,8 +3,8 @@ name = "drand-call"
 version = "1.0.0"
 
 [addresses]
-# drand = "0xba31"
-hello = "0xba31"
+drand = "0xba31"
+hello = "0x1"
 
 [dependencies]
 Games = { local = "../../../../../../../sui_programmability/examples/games" }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/input.json
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/input.json
@@ -1,0 +1,16 @@
+{
+    "program_id": "DozgQiYtGbdyniV2T74xMdmjZJvYDzoRFFqw7UR5MwPK",
+    "accounts": [
+        {
+            "key": "524HMdYYBy6TAn4dK5vCcjiTmT2sxV6Xoue5EXrz22Ca",
+            "owner": "BPFLoaderUpgradeab1e11111111111111111111111",
+            "is_signer": false,
+            "is_writable": true,
+            "lamports": 1000,
+            "data": [0, 0, 0, 3]
+        }
+    ],
+    "instruction_data": [
+        11, 0, 0, 0, 0, 0, 0, 0,
+        104, 101, 108, 108, 111, 95, 95, 109, 97, 105, 110]
+}

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/sources/drand-call.move
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/sources/drand-call.move
@@ -9,8 +9,7 @@ module 0x10::debug {
   native public fun print<T>(x: &T);
 }
 
-// module drand::drand {
-module hello::hello {
+module drand::hello {
     use 0x10::debug;
     use 0x1::string;
     use std::vector;

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/sources/drand-call.move
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/sources/drand-call.move
@@ -1,0 +1,80 @@
+// input ../input.json
+// use-stdlib
+// log 0000000000000000000000000000000000000000000000000000000000000001::string::String { bytes: [72, 101, 108, 108, 111, 32, 100, 114, 97, 110, 100], }
+// log [72, 101, 108, 108, 111]
+// log [24, 95, 141, 179, 34, 113, 254, 37, 245, 97, 166, 252, 147, 139, 46, 38, 67, 6, 236, 48, 78, 218, 81, 128, 7, 209, 118, 72, 38, 56, 25, 105]
+// log 37
+
+module 0x10::debug {
+  native public fun print<T>(x: &T);
+}
+
+// module drand::drand {
+module hello::hello {
+    use 0x10::debug;
+    use 0x1::string;
+    use std::vector;
+
+    /// Error codes
+    const EInvalidRndLength: u64 = 0;
+
+
+    public fun create_u8_vector(): vector<u8> {
+        let v = vector::empty<u8>();
+        vector::push_back(&mut v, 72); // H
+        vector::push_back(&mut v, 101); // e
+        vector::push_back(&mut v, 108); // l
+        vector::push_back(&mut v, 108); // l
+        vector::push_back(&mut v, 111); // o
+        v
+    }
+
+    public fun print_vector_u8(vec: &vector<u8>) {
+        let vec_u8 = vector::empty<u8>();
+        let len = vector::length<u8>(vec);
+
+        let i = 0;
+        while (i < len) {
+            let byte = vector::borrow<u8>(vec, i);
+            vector::push_back<u8>(&mut vec_u8, *byte);
+            i = i + 1;
+        };
+
+        debug::print(&vec_u8);
+    }
+
+    // Converts the first 8 bytes of rnd to a u64 number and outputs its modulo with input n.
+    // Since n is u64, the output is at most 2^{-64} biased assuming rnd is uniformly random.
+    public fun safe_selection(n: u64, rnd: &vector<u8>): u64 {
+        assert!(vector::length(rnd) >= 8, EInvalidRndLength);
+        let m: u64 = 0;
+        let i = 0;
+        while (i < 8) {
+            m = m << 8;
+            let curr_byte = *vector::borrow(rnd, i);
+            m = m + (curr_byte as u64);
+            i = i + 1;
+        };
+        let n_64 = (n as u64);
+        let module_64  = m % n_64;
+        let res = (module_64 as u64);
+        res
+    }
+
+
+    public entry fun main() : u64 {
+        let s = string::utf8(b"Hello drand");
+        debug::print(&s);
+
+        let v = create_u8_vector();
+        print_vector_u8(&v);
+
+        let rand = games::drand_lib::derive_randomness(v);
+        print_vector_u8(&rand);
+
+        let rand_u64 = safe_selection(64, &rand);
+        debug::print(&rand_u64);
+
+        rand_u64
+    }
+}

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/sha-256/Move.toml
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/sha-256/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sha-256"
+version = "1.0.0"
+
+[addresses]
+sha_256 = "0xba31"
+hello = "0x1"
+
+[dependencies]
+MoveStdlib = { local = "../../../../../crates/move-stdlib", addr_subst = { "std" = "0x1" } }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/sha-256/input.json
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/sha-256/input.json
@@ -1,0 +1,16 @@
+{
+    "program_id": "DozgQiYtGbdyniV2T74xMdmjZJvYDzoRFFqw7UR5MwPK",
+    "accounts": [
+        {
+            "key": "524HMdYYBy6TAn4dK5vCcjiTmT2sxV6Xoue5EXrz22Ca",
+            "owner": "BPFLoaderUpgradeab1e11111111111111111111111",
+            "is_signer": false,
+            "is_writable": true,
+            "lamports": 1000,
+            "data": [0, 0, 0, 3]
+        }
+    ],
+    "instruction_data": [
+        11, 0, 0, 0, 0, 0, 0, 0,
+        104, 101, 108, 108, 111, 95, 95, 109, 97, 105, 110]
+}

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/sha-256/sources/sha-256.move
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/sha-256/sources/sha-256.move
@@ -1,0 +1,81 @@
+// input ../input.json
+// use-stdlib
+// log 0000000000000000000000000000000000000000000000000000000000000001::string::String { bytes: [72, 101, 108, 108, 111, 32, 100, 114, 97, 110, 100], }
+// log [72, 101, 108, 108, 111]
+// log [24, 95, 141, 179, 34, 113, 254, 37, 245, 97, 166, 252, 147, 139, 46, 38, 67, 6, 236, 48, 78, 218, 81, 128, 7, 209, 118, 72, 38, 56, 25, 105]
+// log 37
+
+
+module 0x10::debug {
+  native public fun print<T>(x: &T);
+}
+
+module sha_256::hello {
+    use 0x10::debug;
+    use 0x1::string;
+    use std::vector;
+    use std::hash::sha2_256;
+
+    /// Error codes
+    const EInvalidRndLength: u64 = 0;
+
+
+    public fun create_u8_vector(): vector<u8> {
+        let v = vector::empty<u8>();
+        vector::push_back(&mut v, 72); // H
+        vector::push_back(&mut v, 101); // e
+        vector::push_back(&mut v, 108); // l
+        vector::push_back(&mut v, 108); // l
+        vector::push_back(&mut v, 111); // o
+        v
+    }
+
+    public fun print_vector_u8(vec: &vector<u8>) {
+        let vec_u8 = vector::empty<u8>();
+        let len = vector::length<u8>(vec);
+
+        let i = 0;
+        while (i < len) {
+            let byte = vector::borrow<u8>(vec, i);
+            vector::push_back<u8>(&mut vec_u8, *byte);
+            i = i + 1;
+        };
+
+        debug::print(&vec_u8);
+    }
+
+    // Converts the first 8 bytes of rnd to a u64 number and outputs its modulo with input n.
+    // Since n is u64, the output is at most 2^{-64} biased assuming rnd is uniformly random.
+    public fun safe_selection(n: u64, rnd: &vector<u8>): u64 {
+        assert!(vector::length(rnd) >= 8, EInvalidRndLength);
+        let m: u64 = 0;
+        let i = 0;
+        while (i < 8) {
+            m = m << 8;
+            let curr_byte = *vector::borrow(rnd, i);
+            m = m + (curr_byte as u64);
+            i = i + 1;
+        };
+        let n_64 = (n as u64);
+        let module_64  = m % n_64;
+        let res = (module_64 as u64);
+        res
+    }
+
+
+    public entry fun main() : u64 {
+        let s = string::utf8(b"Hello drand");
+        debug::print(&s);
+
+        let v = create_u8_vector();
+        print_vector_u8(&v);
+
+        let rand = std::hash::sha2_256(v);
+        print_vector_u8(&rand);
+
+        let rand_u64 = safe_selection(64, &rand);
+        debug::print(&rand_u64);
+
+        rand_u64
+    }
+}

--- a/external-crates/move/solana/move-to-solana/src/stackless/rttydesc.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/rttydesc.rs
@@ -353,9 +353,12 @@ impl<'mm, 'up> RttyContext<'mm, 'up> {
             _ => unreachable!(),
         };
 
+        debug!(target: "debug", "s_env {:#?}", &s_env);
+
         // Look up the corresponding LLVM struct type constructed earlier in the translation.
         // Use it to collect field offsets, struct size, and struct alignment as computed by LLVM.
         let ll_struct_name = s_env.ll_struct_name_from_raw_name(s_tys);
+        debug!(target: "rtty", "ll_struct_name {:#?}", &ll_struct_name);
         let ll_struct_ty = llcx
             .named_struct_type(&ll_struct_name)
             .expect("no struct type");

--- a/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
@@ -1872,8 +1872,6 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                         return builder
                             .build_load(res_val_type, res_ptr, "reload")
                             .as_constant();
-
-
                     }
                     _ => {
                         todo!("unexpected vec constant: {}: {:#?}", val_vec.len(), val_vec);


### PR DESCRIPTION
Similar to `drand` test #54 , but here we use more standardized `std::hash::sha2_256`.

Test code is shorter and simple.

Good news is that two different tests compute the same value.
