### PR TITLE
Fixing empty vector. Also 2 tests in rbpf and 1 test in failures added.

### DIFF
--- a/external-crates/move/crates/move-stackless-bytecode/src/stackless_bytecode.rs
+++ b/external-crates/move/crates/move-stackless-bytecode/src/stackless_bytecode.rs
@@ -104,6 +104,18 @@ impl From<&u256::U256> for Constant {
         Constant::U256(U256::from(n))
     }
 }
+impl From<&Vec<u8>> for Constant {
+    fn from(v: &Vec<u8>) -> Constant {
+        Constant::ByteArray(v.clone())
+    }
+}
+
+pub fn transform_bytearray_to_vec(val_vec: &[Constant]) -> Option<&Vec<u8>> {
+    if let Some(Constant::ByteArray(ref vec)) = val_vec.first() {
+        return Some(vec);
+    }
+    None
+}
 
 /// An operation -- target of a call. This contains user functions, builtin functions, and
 /// operators.

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin/Move.toml
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/dwarf-tests/basic-coin/Move.toml
@@ -6,5 +6,5 @@ version = "0.0.0"
 NamedAddr = "0xCAFE"
 std = "0x1"
 
-[dependencies]
-MoveStdlib = { local = "../../../../../crates/move-stdlib/" }
+# [dependencies]
+# MoveStdlib = { local = "../../../../../crates/move-stdlib/" }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests.rs
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests.rs
@@ -59,6 +59,7 @@ datatest_stable::harness!(run_test, TEST_DIR, r".*\.move$");
 
 fn run_test(test_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     tc::setup_logging_for_test();
+    dbg!(test_path);
     Ok(run_test_inner(test_path)?)
 }
 
@@ -76,9 +77,10 @@ fn run_test_inner(test_path: &Path) -> anyhow::Result<()> {
         &harness_paths,
         &test_plan,
         vec![
-            &"--stdlib".to_string(),
+            // &"--stdlib".to_string(),
             &"--test".to_string(),
-            &"--dev".to_string(),
+            // &dep_option,
+            // &"--dev".to_string(),
             &"-O".to_string(),
         ],
     )?;

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/Move.toml
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "drand-call"
+version = "1.0.0"
+
+[addresses]
+drand = "0xba31"
+hello = "0x1"
+sui = "0x2"
+
+[dependencies]
+Games = { local = "../../../../../../../sui_programmability/examples/games" }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x0__drand_lib.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x0__drand_lib.ll.expected
@@ -1,0 +1,552 @@
+; ModuleID = '0x0__drand_lib'
+source_filename = "../../../../../../../sui_programmability/examples/games/sources/drand_lib.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+@__move_rttydesc_u8 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u8_name, i64 2 }, i64 2, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u8_name = private unnamed_addr constant [2 x i8] c"u8"
+@vec_literal = internal constant [8 x i8] zeroinitializer
+@vdesc = internal constant { ptr, i64, i64 } { ptr @vec_literal, i64 8, i64 8 }
+@vec_literal.1 = internal constant [96 x i8] c"\83\CF\0F(\96\AD\EE~\B8\B5\F0\1F\CA\D3\91\22\12\C47\E0\07>\91\1F\B9\00\22\D3\E7`\18<\8CKE\0Bj\0Al:\C6\A5wj-\10dQ\0D\1F\ECu\8C\92\1C\C2+\0E\17\E6:\AFK\CB^\D6c\04\DE\9C\F8\09\BD'L\A7;\ABJ\F5\A6\E9\C7jK\C0\9Ev\EA\E8\99\1E\F5\EC\E4Z"
+@vdesc.2 = internal constant { ptr, i64, i64 } { ptr @vec_literal.1, i64 96, i64 96 }
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define void @"0000000000000000_drand_lib_unit_test_poiso_21yHPxbFTjmohy"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+define { ptr, i64, i64 } @"0000000000000000_drand_lib_derive_randomne_6ohYzVYDX2EpLR"({ ptr, i64, i64 } %0) {
+entry:
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store { ptr, i64, i64 } %0, ptr %local_0, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_0, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_hash_sha2_256(ptr %local_1)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+declare { ptr, i64, i64 } @move_native_hash_sha2_256(ptr)
+
+define i64 @"0000000000000000_drand_lib_safe_selection_2PgCpYp2scFABe"(i64 %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca i128, align 8
+  %local_5 = alloca i128, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i1, align 1
+  %local_10 = alloca ptr, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca i128, align 8
+  %local_13 = alloca i64, align 8
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca i1, align 1
+  %local_17 = alloca i128, align 8
+  %local_18 = alloca i8, align 1
+  %local_19 = alloca i128, align 8
+  %local_20 = alloca ptr, align 8
+  %local_21 = alloca i64, align 8
+  %local_22 = alloca ptr, align 8
+  %local_23 = alloca i8, align 1
+  %local_24 = alloca i128, align 8
+  %local_25 = alloca i8, align 1
+  %local_26 = alloca i128, align 8
+  %local_27 = alloca i128, align 8
+  %local_28 = alloca i64, align 8
+  %local_29 = alloca i64, align 8
+  %local_30 = alloca i64, align 8
+  %local_31 = alloca ptr, align 8
+  %local_32 = alloca i64, align 8
+  %local_33 = alloca i128, align 8
+  %local_34 = alloca i128, align 8
+  %local_35 = alloca i128, align 8
+  %local_36 = alloca i128, align 8
+  %local_37 = alloca i64, align 8
+  store i64 %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  %load_store_tmp = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp, ptr %local_6, align 8
+  %loaded_alloca = load ptr, ptr %local_6, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_7, align 8
+  store i64 16, ptr %local_8, align 8
+  %ge_src_0 = load i64, ptr %local_7, align 8
+  %ge_src_1 = load i64, ptr %local_8, align 8
+  %ge_dst = icmp uge i64 %ge_src_0, %ge_src_1
+  store i1 %ge_dst, ptr %local_9, align 1
+  %cnd = load i1, ptr %local_9, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_10, align 8
+  store i64 0, ptr %local_11, align 8
+  %call_arg_0 = load i64, ptr %local_11, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  store i128 0, ptr %local_12, align 8
+  %load_store_tmp2 = load i128, ptr %local_12, align 8
+  store i128 %load_store_tmp2, ptr %local_4, align 8
+  store i64 0, ptr %local_13, align 8
+  %load_store_tmp3 = load i64, ptr %local_13, align 8
+  store i64 %load_store_tmp3, ptr %local_3, align 8
+  br label %bb_6
+
+bb_6:                                             ; preds = %join_bb26, %bb_2
+  %load_store_tmp4 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp4, ptr %local_14, align 8
+  store i64 16, ptr %local_15, align 8
+  %lt_src_0 = load i64, ptr %local_14, align 8
+  %lt_src_1 = load i64, ptr %local_15, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_16, align 1
+  %cnd5 = load i1, ptr %local_16, align 1
+  br i1 %cnd5, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_6
+  br label %bb_5
+
+bb_5:                                             ; preds = %bb_4
+  %load_store_tmp6 = load i128, ptr %local_4, align 8
+  store i128 %load_store_tmp6, ptr %local_17, align 8
+  store i8 8, ptr %local_18, align 1
+  %shl_src_0 = load i128, ptr %local_17, align 8
+  %shl_src_1 = load i8, ptr %local_18, align 1
+  %rangecond = icmp uge i8 %shl_src_1, -128
+  br i1 %rangecond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_5
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_5
+  %zext_dst = zext i8 %shl_src_1 to i128
+  %shl_dst = shl i128 %shl_src_0, %zext_dst
+  store i128 %shl_dst, ptr %local_19, align 8
+  %load_store_tmp7 = load i128, ptr %local_19, align 8
+  store i128 %load_store_tmp7, ptr %local_4, align 8
+  %load_store_tmp8 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp8, ptr %local_20, align 8
+  %load_store_tmp9 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp9, ptr %local_21, align 8
+  %loaded_alloca10 = load ptr, ptr %local_20, align 8
+  %loaded_alloca11 = load i64, ptr %local_21, align 8
+  %retval12 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_u8, ptr %loaded_alloca10, i64 %loaded_alloca11)
+  store ptr %retval12, ptr %local_22, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_22, align 8
+  %load_deref_store_tmp2 = load i8, ptr %load_deref_store_tmp1, align 1
+  store i8 %load_deref_store_tmp2, ptr %local_23, align 1
+  %load_store_tmp13 = load i8, ptr %local_23, align 1
+  store i8 %load_store_tmp13, ptr %local_2, align 1
+  %load_store_tmp14 = load i128, ptr %local_4, align 8
+  store i128 %load_store_tmp14, ptr %local_24, align 8
+  %load_store_tmp15 = load i8, ptr %local_2, align 1
+  store i8 %load_store_tmp15, ptr %local_25, align 1
+  %cast_src = load i8, ptr %local_25, align 1
+  %zext_dst16 = zext i8 %cast_src to i128
+  store i128 %zext_dst16, ptr %local_26, align 8
+  %add_src_0 = load i128, ptr %local_24, align 8
+  %add_src_1 = load i128, ptr %local_26, align 8
+  %add_dst = add i128 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i128 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb17, label %join_bb18
+
+then_bb17:                                        ; preds = %join_bb
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb18:                                        ; preds = %join_bb
+  store i128 %add_dst, ptr %local_27, align 8
+  %load_store_tmp19 = load i128, ptr %local_27, align 8
+  store i128 %load_store_tmp19, ptr %local_4, align 8
+  %load_store_tmp20 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp20, ptr %local_28, align 8
+  store i64 1, ptr %local_29, align 8
+  %add_src_021 = load i64, ptr %local_28, align 8
+  %add_src_122 = load i64, ptr %local_29, align 8
+  %add_dst23 = add i64 %add_src_021, %add_src_122
+  %ovfcond24 = icmp ult i64 %add_dst23, %add_src_021
+  br i1 %ovfcond24, label %then_bb25, label %join_bb26
+
+then_bb25:                                        ; preds = %join_bb18
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb26:                                        ; preds = %join_bb18
+  store i64 %add_dst23, ptr %local_30, align 8
+  %load_store_tmp27 = load i64, ptr %local_30, align 8
+  store i64 %load_store_tmp27, ptr %local_3, align 8
+  br label %bb_6
+
+bb_3:                                             ; preds = %bb_6
+  %load_store_tmp28 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp28, ptr %local_31, align 8
+  %load_store_tmp29 = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp29, ptr %local_32, align 8
+  %cast_src30 = load i64, ptr %local_32, align 8
+  %zext_dst31 = zext i64 %cast_src30 to i128
+  store i128 %zext_dst31, ptr %local_33, align 8
+  %load_store_tmp32 = load i128, ptr %local_33, align 8
+  store i128 %load_store_tmp32, ptr %local_5, align 8
+  %load_store_tmp33 = load i128, ptr %local_4, align 8
+  store i128 %load_store_tmp33, ptr %local_34, align 8
+  %load_store_tmp34 = load i128, ptr %local_5, align 8
+  store i128 %load_store_tmp34, ptr %local_35, align 8
+  %mod_src_0 = load i128, ptr %local_34, align 8
+  %mod_src_1 = load i128, ptr %local_35, align 8
+  %zerocond = icmp eq i128 %mod_src_1, 0
+  br i1 %zerocond, label %then_bb35, label %join_bb36
+
+then_bb35:                                        ; preds = %bb_3
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb36:                                        ; preds = %bb_3
+  %mod_dst = urem i128 %mod_src_0, %mod_src_1
+  store i128 %mod_dst, ptr %local_36, align 8
+  %cast_src37 = load i128, ptr %local_36, align 8
+  %castcond = icmp ugt i128 %cast_src37, 18446744073709551615
+  br i1 %castcond, label %then_bb38, label %join_bb39
+
+then_bb38:                                        ; preds = %join_bb36
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb39:                                        ; preds = %join_bb36
+  %trunc_dst = trunc i128 %cast_src37 to i64
+  store i64 %trunc_dst, ptr %local_37, align 8
+  %retval40 = load i64, ptr %local_37, align 8
+  ret i64 %retval40
+}
+
+declare i64 @move_native_vector_length(ptr, ptr)
+
+declare ptr @move_native_vector_borrow(ptr, ptr, i64)
+
+define void @"0000000000000000_drand_lib_verify_drand_si_jZCgvkpsfLYXch"({ ptr, i64, i64 } %0, i64 %1) {
+entry:
+  %newv23 = alloca { ptr, i64, i64 }, align 8
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca { ptr, i64, i64 }, align 8
+  %local_5 = alloca { ptr, i64, i64 }, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca i64, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca i1, align 1
+  %local_13 = alloca i64, align 8
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca ptr, align 8
+  %local_17 = alloca i64, align 8
+  %local_18 = alloca ptr, align 8
+  %local_19 = alloca i64, align 8
+  %local_20 = alloca i8, align 1
+  %local_21 = alloca ptr, align 8
+  %local_22 = alloca i64, align 8
+  %local_23 = alloca i8, align 1
+  %local_24 = alloca i64, align 8
+  %local_25 = alloca i64, align 8
+  %local_26 = alloca i64, align 8
+  %local_27 = alloca i64, align 8
+  %local_28 = alloca { ptr, i64, i64 }, align 8
+  %local_29 = alloca { ptr, i64, i64 }, align 8
+  %local_30 = alloca { ptr, i64, i64 }, align 8
+  %local_31 = alloca ptr, align 8
+  %local_32 = alloca ptr, align 8
+  %local_33 = alloca ptr, align 8
+  %local_34 = alloca i1, align 1
+  %local_35 = alloca i64, align 8
+  store { ptr, i64, i64 } %0, ptr %local_0, align 8
+  store i64 %1, ptr %local_1, align 8
+  %2 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %2, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_8, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_8, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_7, align 8
+  store i64 7, ptr %local_9, align 8
+  %load_store_tmp1 = load i64, ptr %local_9, align 8
+  store i64 %load_store_tmp1, ptr %local_6, align 8
+  br label %bb_3
+
+bb_3:                                             ; preds = %join_bb18, %entry
+  %load_store_tmp2 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp2, ptr %local_10, align 8
+  store i64 0, ptr %local_11, align 8
+  %gt_src_0 = load i64, ptr %local_10, align 8
+  %gt_src_1 = load i64, ptr %local_11, align 8
+  %gt_dst = icmp ugt i64 %gt_src_0, %gt_src_1
+  store i1 %gt_dst, ptr %local_12, align 1
+  %cnd = load i1, ptr %local_12, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %bb_3
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_1
+  %load_store_tmp3 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp3, ptr %local_13, align 8
+  store i64 256, ptr %local_14, align 8
+  %mod_src_0 = load i64, ptr %local_13, align 8
+  %mod_src_1 = load i64, ptr %local_14, align 8
+  %zerocond = icmp eq i64 %mod_src_1, 0
+  br i1 %zerocond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_2
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_2
+  %mod_dst = urem i64 %mod_src_0, %mod_src_1
+  store i64 %mod_dst, ptr %local_15, align 8
+  %load_store_tmp4 = load i64, ptr %local_15, align 8
+  store i64 %load_store_tmp4, ptr %local_2, align 8
+  store ptr %local_7, ptr %local_16, align 8
+  %load_store_tmp5 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp5, ptr %local_17, align 8
+  %loaded_alloca = load ptr, ptr %local_16, align 8
+  %loaded_alloca6 = load i64, ptr %local_17, align 8
+  %retval = call ptr @move_native_vector_borrow_mut(ptr @__move_rttydesc_u8, ptr %loaded_alloca, i64 %loaded_alloca6)
+  store ptr %retval, ptr %local_18, align 8
+  %load_store_tmp7 = load ptr, ptr %local_18, align 8
+  store ptr %load_store_tmp7, ptr %local_3, align 8
+  %load_store_tmp8 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp8, ptr %local_19, align 8
+  %cast_src = load i64, ptr %local_19, align 8
+  %castcond = icmp ugt i64 %cast_src, 255
+  br i1 %castcond, label %then_bb9, label %join_bb10
+
+then_bb9:                                         ; preds = %join_bb
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb10:                                        ; preds = %join_bb
+  %trunc_dst = trunc i64 %cast_src to i8
+  store i8 %trunc_dst, ptr %local_20, align 1
+  %load_store_tmp11 = load ptr, ptr %local_3, align 8
+  store ptr %load_store_tmp11, ptr %local_21, align 8
+  %load_store_ref_src = load i8, ptr %local_20, align 1
+  %load_store_ref_dst_ptr = load ptr, ptr %local_21, align 8
+  store i8 %load_store_ref_src, ptr %load_store_ref_dst_ptr, align 1
+  %load_store_tmp12 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp12, ptr %local_22, align 8
+  store i8 8, ptr %local_23, align 1
+  %shr_src_0 = load i64, ptr %local_22, align 8
+  %shr_src_1 = load i8, ptr %local_23, align 1
+  %rangecond = icmp uge i8 %shr_src_1, 64
+  br i1 %rangecond, label %then_bb13, label %join_bb14
+
+then_bb13:                                        ; preds = %join_bb10
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb14:                                        ; preds = %join_bb10
+  %zext_dst = zext i8 %shr_src_1 to i64
+  %shr_dst = lshr i64 %shr_src_0, %zext_dst
+  store i64 %shr_dst, ptr %local_24, align 8
+  %load_store_tmp15 = load i64, ptr %local_24, align 8
+  store i64 %load_store_tmp15, ptr %local_1, align 8
+  %load_store_tmp16 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp16, ptr %local_25, align 8
+  store i64 1, ptr %local_26, align 8
+  %sub_src_0 = load i64, ptr %local_25, align 8
+  %sub_src_1 = load i64, ptr %local_26, align 8
+  %sub_dst = sub i64 %sub_src_0, %sub_src_1
+  %ovfcond = icmp ugt i64 %sub_dst, %sub_src_0
+  br i1 %ovfcond, label %then_bb17, label %join_bb18
+
+then_bb17:                                        ; preds = %join_bb14
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb18:                                        ; preds = %join_bb14
+  store i64 %sub_dst, ptr %local_27, align 8
+  %load_store_tmp19 = load i64, ptr %local_27, align 8
+  store i64 %load_store_tmp19, ptr %local_6, align 8
+  br label %bb_3
+
+bb_0:                                             ; preds = %bb_3
+  %load_store_tmp20 = load { ptr, i64, i64 }, ptr %local_7, align 8
+  store { ptr, i64, i64 } %load_store_tmp20, ptr %local_28, align 8
+  %retval21 = call { ptr, i64, i64 } @move_native_hash_sha2_256(ptr %local_28)
+  store { ptr, i64, i64 } %retval21, ptr %local_29, align 8
+  %load_store_tmp22 = load { ptr, i64, i64 }, ptr %local_29, align 8
+  store { ptr, i64, i64 } %load_store_tmp22, ptr %local_4, align 8
+  %3 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %3, ptr %newv23, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv23, ptr @vdesc.2)
+  %reload24 = load { ptr, i64, i64 }, ptr %newv23, align 8
+  store { ptr, i64, i64 } %reload24, ptr %local_30, align 8
+  %load_store_tmp25 = load { ptr, i64, i64 }, ptr %local_30, align 8
+  store { ptr, i64, i64 } %load_store_tmp25, ptr %local_5, align 8
+  store ptr %local_0, ptr %local_31, align 8
+  store ptr %local_5, ptr %local_32, align 8
+  store ptr %local_4, ptr %local_33, align 8
+  %loaded_alloca26 = load ptr, ptr %local_31, align 8
+  %loaded_alloca27 = load ptr, ptr %local_32, align 8
+  %loaded_alloca28 = load ptr, ptr %local_33, align 8
+  %retval29 = call i1 @move_native_bls12381_bls12381_min_sig_verify(ptr %loaded_alloca26, ptr %loaded_alloca27, ptr %loaded_alloca28)
+  store i1 %retval29, ptr %local_34, align 1
+  %cnd30 = load i1, ptr %local_34, align 1
+  br i1 %cnd30, label %bb_5, label %bb_4
+
+bb_5:                                             ; preds = %bb_0
+  br label %bb_6
+
+bb_4:                                             ; preds = %bb_0
+  store i64 1, ptr %local_35, align 8
+  %call_arg_0 = load i64, ptr %local_35, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_6:                                             ; preds = %bb_5
+  ret void
+}
+
+declare ptr @move_native_vector_borrow_mut(ptr, ptr, i64)
+
+declare i1 @move_native_bls12381_bls12381_min_sig_verify(ptr, ptr, ptr)
+
+define void @"0000000000000000_drand_lib_verify_time_has_FnagknQZ5yuPFj"(i64 %0, { ptr, i64, i64 } %1, i64 %2) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca i64, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca i64, align 8
+  %local_11 = alloca i1, align 1
+  %local_12 = alloca i64, align 8
+  %local_13 = alloca { ptr, i64, i64 }, align 8
+  %local_14 = alloca i64, align 8
+  store i64 %0, ptr %local_0, align 8
+  store { ptr, i64, i64 } %1, ptr %local_1, align 8
+  store i64 %2, ptr %local_2, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_3, align 8
+  store i64 1692803367, ptr %local_4, align 8
+  store i64 3, ptr %local_5, align 8
+  %load_store_tmp1 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp1, ptr %local_6, align 8
+  store i64 1, ptr %local_7, align 8
+  %sub_src_0 = load i64, ptr %local_6, align 8
+  %sub_src_1 = load i64, ptr %local_7, align 8
+  %sub_dst = sub i64 %sub_src_0, %sub_src_1
+  %ovfcond = icmp ugt i64 %sub_dst, %sub_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
+  store i64 %sub_dst, ptr %local_8, align 8
+  %mul_src_0 = load i64, ptr %local_5, align 8
+  %mul_src_1 = load i64, ptr %local_8, align 8
+  %mul_val = call { i64, i1 } @llvm.umul.with.overflow.i64(i64 %mul_src_0, i64 %mul_src_1)
+  %mul_dst = extractvalue { i64, i1 } %mul_val, 0
+  %mul_ovf = extractvalue { i64, i1 } %mul_val, 1
+  br i1 %mul_ovf, label %then_bb2, label %join_bb3
+
+then_bb2:                                         ; preds = %join_bb
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb3:                                         ; preds = %join_bb
+  store i64 %mul_dst, ptr %local_9, align 8
+  %add_src_0 = load i64, ptr %local_4, align 8
+  %add_src_1 = load i64, ptr %local_9, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond4 = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond4, label %then_bb5, label %join_bb6
+
+then_bb5:                                         ; preds = %join_bb3
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb6:                                         ; preds = %join_bb3
+  store i64 %add_dst, ptr %local_10, align 8
+  %le_src_0 = load i64, ptr %local_3, align 8
+  %le_src_1 = load i64, ptr %local_10, align 8
+  %le_dst = icmp ule i64 %le_src_0, %le_src_1
+  store i1 %le_dst, ptr %local_11, align 1
+  %cnd = load i1, ptr %local_11, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %join_bb6
+  br label %bb_2
+
+bb_0:                                             ; preds = %join_bb6
+  store i64 1, ptr %local_12, align 8
+  %call_arg_0 = load i64, ptr %local_12, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  %load_store_tmp7 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp7, ptr %local_13, align 8
+  %load_store_tmp8 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp8, ptr %local_14, align 8
+  %call_arg_09 = load { ptr, i64, i64 }, ptr %local_13, align 8
+  %call_arg_1 = load i64, ptr %local_14, align 8
+  call void @"0000000000000000_drand_lib_verify_drand_si_jZCgvkpsfLYXch"({ ptr, i64, i64 } %call_arg_09, i64 %call_arg_1)
+  ret void
+}
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)
+
+; Function Attrs: cold noreturn
+declare void @move_rt_abort(i64) #0
+
+declare { ptr, i64, i64 } @move_rt_vec_empty(ptr nonnull readonly dereferenceable(32))
+
+declare void @move_rt_vec_copy(ptr nonnull readonly dereferenceable(32), ptr nonnull dereferenceable(24), ptr nonnull readonly dereferenceable(24))
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare { i64, i1 } @llvm.umul.with.overflow.i64(i64, i64) #1
+
+attributes #0 = { cold noreturn }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x10__debug.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x10__debug.ll.expected
@@ -1,0 +1,30 @@
+; ModuleID = '0x10__debug'
+source_filename = "drand-call.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define void @"0000000000000010_debug_unit_test_poiso_7YrRnE6n5X5NSv"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+declare void @move_native_debug_print(ptr, ptr)
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x1__ascii.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x1__ascii.ll.expected
@@ -1,0 +1,684 @@
+; ModuleID = '0x1__ascii'
+source_filename = "../../../../../../../crates/sui-framework/packages/move-stdlib/sources/ascii.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+%struct.ascii__String = type { { ptr, i64, i64 } }
+%struct.option__Option_ascii__String_ = type { { ptr, i64, i64 } }
+%struct.ascii__Char = type { i8 }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+@__move_rttydesc_u8 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u8_name, i64 2 }, i64 2, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u8_name = private unnamed_addr constant [2 x i8] c"u8"
+@__move_rttydesc_ascii__String = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_ascii__String_name, i64 79 }, i64 11, ptr @__move_rttydesc_ascii__String_info }
+@__move_rttydesc_ascii__String_name = private unnamed_addr constant [79 x i8] c"0000000000000000000000000000000000000000000000000000000000000001::ascii::String"
+@__move_rttydesc_vector_u8__name = private unnamed_addr constant [10 x i8] c"vector<u8>"
+@__move_rttydesc_vector_u8__info = private unnamed_addr constant { ptr } { ptr @__move_rttydesc_u8 }
+@0 = private unnamed_addr constant [5 x i8] c"bytes"
+@s_fld_array = private unnamed_addr constant [1 x { %__move_rt_type, i64, { ptr, i64 } }] [{ %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_u8__name, i64 10 }, i64 10, ptr @__move_rttydesc_vector_u8__info }, i64 0, { ptr, i64 } { ptr @0, i64 5 } }]
+@__move_rttydesc_ascii__String_info = private unnamed_addr constant { ptr, i64, i64, i64 } { ptr @s_fld_array, i64 1, i64 24, i64 8 }
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define void @"0000000000000001_ascii_unit_test_poiso_F6hmat17gTC3vy"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+define i64 @"0000000000000001_ascii_length_A6pXDkwfFB6jif"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i64, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %call_arg_0 = load ptr, ptr %local_1, align 8
+  %retval = call ptr @"0000000000000001_ascii_as_bytes_5TJmf5DLy2VeUn"(ptr %call_arg_0)
+  store ptr %retval, ptr %local_2, align 8
+  %loaded_alloca = load ptr, ptr %local_2, align 8
+  %retval1 = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval1, ptr %local_3, align 8
+  %retval2 = load i64, ptr %local_3, align 8
+  ret i64 %retval2
+}
+
+define ptr @"0000000000000001_ascii_as_bytes_5TJmf5DLy2VeUn"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2__bytes = alloca ptr, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %tmp = load ptr, ptr %local_1, align 8
+  %fld_ref = getelementptr inbounds %struct.ascii__String, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_2__bytes, align 8
+  %retval = load ptr, ptr %local_2__bytes, align 8
+  ret ptr %retval
+}
+
+declare i64 @move_native_vector_length(ptr, ptr)
+
+define i1 @"0000000000000001_ascii_all_characters__9BLTK39sPauxug"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4__bytes = alloca ptr, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i1, align 1
+  %local_10 = alloca ptr, align 8
+  %local_11__bytes = alloca ptr, align 8
+  %local_12 = alloca i64, align 8
+  %local_13 = alloca ptr, align 8
+  %local_14 = alloca i8, align 1
+  %local_15 = alloca i1, align 1
+  %local_16 = alloca i1, align 1
+  %local_17 = alloca ptr, align 8
+  %local_18 = alloca i1, align 1
+  %local_19 = alloca i64, align 8
+  %local_20 = alloca i64, align 8
+  %local_21 = alloca i64, align 8
+  %local_22 = alloca ptr, align 8
+  %local_23 = alloca i1, align 1
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %tmp = load ptr, ptr %local_3, align 8
+  %fld_ref = getelementptr inbounds %struct.ascii__String, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_4__bytes, align 8
+  %loaded_alloca = load ptr, ptr %local_4__bytes, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_5, align 8
+  %load_store_tmp1 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp1, ptr %local_2, align 8
+  store i64 0, ptr %local_6, align 8
+  %load_store_tmp2 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp2, ptr %local_1, align 8
+  br label %bb_5
+
+bb_5:                                             ; preds = %join_bb, %entry
+  %load_store_tmp3 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp3, ptr %local_7, align 8
+  %load_store_tmp4 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp4, ptr %local_8, align 8
+  %lt_src_0 = load i64, ptr %local_7, align 8
+  %lt_src_1 = load i64, ptr %local_8, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_9, align 1
+  %cnd = load i1, ptr %local_9, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %bb_5
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_1
+  %load_store_tmp5 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp5, ptr %local_10, align 8
+  %tmp6 = load ptr, ptr %local_10, align 8
+  %fld_ref7 = getelementptr inbounds %struct.ascii__String, ptr %tmp6, i32 0, i32 0
+  store ptr %fld_ref7, ptr %local_11__bytes, align 8
+  %load_store_tmp8 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp8, ptr %local_12, align 8
+  %loaded_alloca9 = load ptr, ptr %local_11__bytes, align 8
+  %loaded_alloca10 = load i64, ptr %local_12, align 8
+  %retval11 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_u8, ptr %loaded_alloca9, i64 %loaded_alloca10)
+  store ptr %retval11, ptr %local_13, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_13, align 8
+  %load_deref_store_tmp2 = load i8, ptr %load_deref_store_tmp1, align 1
+  store i8 %load_deref_store_tmp2, ptr %local_14, align 1
+  %call_arg_0 = load i8, ptr %local_14, align 1
+  %retval12 = call i1 @"0000000000000001_ascii_is_printable_ch_2sZSN1V1nCDQSy"(i8 %call_arg_0)
+  store i1 %retval12, ptr %local_15, align 1
+  %not_src = load i1, ptr %local_15, align 1
+  %not_dst = xor i1 %not_src, true
+  store i1 %not_dst, ptr %local_16, align 1
+  %cnd13 = load i1, ptr %local_16, align 1
+  br i1 %cnd13, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  %load_store_tmp14 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp14, ptr %local_17, align 8
+  store i1 false, ptr %local_18, align 1
+  %retval15 = load i1, ptr %local_18, align 1
+  ret i1 %retval15
+
+bb_3:                                             ; preds = %bb_2
+  %load_store_tmp16 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp16, ptr %local_19, align 8
+  store i64 1, ptr %local_20, align 8
+  %add_src_0 = load i64, ptr %local_19, align 8
+  %add_src_1 = load i64, ptr %local_20, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_3
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_3
+  store i64 %add_dst, ptr %local_21, align 8
+  %load_store_tmp17 = load i64, ptr %local_21, align 8
+  store i64 %load_store_tmp17, ptr %local_1, align 8
+  br label %bb_5
+
+bb_0:                                             ; preds = %bb_5
+  %load_store_tmp18 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp18, ptr %local_22, align 8
+  store i1 true, ptr %local_23, align 1
+  %retval19 = load i1, ptr %local_23, align 1
+  ret i1 %retval19
+}
+
+declare ptr @move_native_vector_borrow(ptr, ptr, i64)
+
+define i1 @"0000000000000001_ascii_is_printable_ch_2sZSN1V1nCDQSy"(i8 %0) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i1, align 1
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca i8, align 1
+  %local_6 = alloca i8, align 1
+  %local_7 = alloca i1, align 1
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca i1, align 1
+  store i8 %0, ptr %local_0, align 1
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_2, align 1
+  store i8 32, ptr %local_3, align 1
+  %ge_src_0 = load i8, ptr %local_2, align 1
+  %ge_src_1 = load i8, ptr %local_3, align 1
+  %ge_dst = icmp uge i8 %ge_src_0, %ge_src_1
+  store i1 %ge_dst, ptr %local_4, align 1
+  %cnd = load i1, ptr %local_4, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  %load_store_tmp1 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp1, ptr %local_5, align 1
+  store i8 126, ptr %local_6, align 1
+  %le_src_0 = load i8, ptr %local_5, align 1
+  %le_src_1 = load i8, ptr %local_6, align 1
+  %le_dst = icmp ule i8 %le_src_0, %le_src_1
+  store i1 %le_dst, ptr %local_7, align 1
+  %load_store_tmp2 = load i1, ptr %local_7, align 1
+  store i1 %load_store_tmp2, ptr %local_1, align 1
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i1 false, ptr %local_8, align 1
+  %load_store_tmp3 = load i1, ptr %local_8, align 1
+  store i1 %load_store_tmp3, ptr %local_1, align 1
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_0, %bb_1
+  %load_store_tmp4 = load i1, ptr %local_1, align 1
+  store i1 %load_store_tmp4, ptr %local_9, align 1
+  %retval = load i1, ptr %local_9, align 1
+  ret i1 %retval
+}
+
+define %struct.ascii__String @"0000000000000001_ascii_string_5ZneJ22oLb5aDc"({ ptr, i64, i64 } %0) {
+entry:
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca %struct.option__Option_ascii__String_, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca %struct.option__Option_ascii__String_, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca i1, align 1
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca %struct.option__Option_ascii__String_, align 8
+  %local_8 = alloca %struct.ascii__String, align 8
+  store { ptr, i64, i64 } %0, ptr %local_0, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_0, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_2, align 8
+  %call_arg_0 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  %retval = call %struct.option__Option_ascii__String_ @"0000000000000001_ascii_try_string_5cJpK43wC2xgVx"({ ptr, i64, i64 } %call_arg_0)
+  store %struct.option__Option_ascii__String_ %retval, ptr %local_3, align 8
+  %load_store_tmp1 = load %struct.option__Option_ascii__String_, ptr %local_3, align 8
+  store %struct.option__Option_ascii__String_ %load_store_tmp1, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_4, align 8
+  %call_arg_02 = load ptr, ptr %local_4, align 8
+  %retval3 = call i1 @"0000000000000001_option_is_some_3HbPGsdEGsnX7R"(ptr %call_arg_02)
+  store i1 %retval3, ptr %local_5, align 1
+  %cnd = load i1, ptr %local_5, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i64 65536, ptr %local_6, align 8
+  %call_arg_04 = load i64, ptr %local_6, align 8
+  call void @move_rt_abort(i64 %call_arg_04)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  %call_arg_05 = load %struct.option__Option_ascii__String_, ptr %local_1, align 8
+  %retval6 = call %struct.ascii__String @"0000000000000001_option_destroy_some_6qpnBkqx6R338H"(%struct.option__Option_ascii__String_ %call_arg_05)
+  store %struct.ascii__String %retval6, ptr %local_8, align 8
+  %retval7 = load %struct.ascii__String, ptr %local_8, align 8
+  ret %struct.ascii__String %retval7
+}
+
+define %struct.option__Option_ascii__String_ @"0000000000000001_ascii_try_string_5cJpK43wC2xgVx"({ ptr, i64, i64 } %0) {
+entry:
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i64, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca ptr, align 8
+  %local_10 = alloca i64, align 8
+  %local_11 = alloca ptr, align 8
+  %local_12 = alloca i8, align 1
+  %local_13 = alloca i1, align 1
+  %local_14 = alloca i1, align 1
+  %local_15 = alloca %struct.option__Option_ascii__String_, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca i64, align 8
+  %local_18 = alloca i64, align 8
+  %local_19__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_20 = alloca %struct.ascii__String, align 8
+  %local_21 = alloca %struct.option__Option_ascii__String_, align 8
+  store { ptr, i64, i64 } %0, ptr %local_0, align 8
+  store ptr %local_0, ptr %local_3, align 8
+  %loaded_alloca = load ptr, ptr %local_3, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_4, align 8
+  %load_store_tmp = load i64, ptr %local_4, align 8
+  store i64 %load_store_tmp, ptr %local_2, align 8
+  store i64 0, ptr %local_5, align 8
+  %load_store_tmp1 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp1, ptr %local_1, align 8
+  br label %bb_5
+
+bb_5:                                             ; preds = %join_bb, %entry
+  %load_store_tmp2 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp2, ptr %local_6, align 8
+  %load_store_tmp3 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp3, ptr %local_7, align 8
+  %lt_src_0 = load i64, ptr %local_6, align 8
+  %lt_src_1 = load i64, ptr %local_7, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_8, align 1
+  %cnd = load i1, ptr %local_8, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %bb_5
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_1
+  store ptr %local_0, ptr %local_9, align 8
+  %load_store_tmp4 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp4, ptr %local_10, align 8
+  %loaded_alloca5 = load ptr, ptr %local_9, align 8
+  %loaded_alloca6 = load i64, ptr %local_10, align 8
+  %retval7 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_u8, ptr %loaded_alloca5, i64 %loaded_alloca6)
+  store ptr %retval7, ptr %local_11, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_11, align 8
+  %load_deref_store_tmp2 = load i8, ptr %load_deref_store_tmp1, align 1
+  store i8 %load_deref_store_tmp2, ptr %local_12, align 1
+  %call_arg_0 = load i8, ptr %local_12, align 1
+  %retval8 = call i1 @"0000000000000001_ascii_is_valid_char_DoZuGpdUuUxshB"(i8 %call_arg_0)
+  store i1 %retval8, ptr %local_13, align 1
+  %not_src = load i1, ptr %local_13, align 1
+  %not_dst = xor i1 %not_src, true
+  store i1 %not_dst, ptr %local_14, align 1
+  %cnd9 = load i1, ptr %local_14, align 1
+  br i1 %cnd9, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  %retval10 = call %struct.option__Option_ascii__String_ @"0000000000000001_option_none_EQcMcKEA3CrrkT"()
+  store %struct.option__Option_ascii__String_ %retval10, ptr %local_15, align 8
+  %retval11 = load %struct.option__Option_ascii__String_, ptr %local_15, align 8
+  ret %struct.option__Option_ascii__String_ %retval11
+
+bb_3:                                             ; preds = %bb_2
+  %load_store_tmp12 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp12, ptr %local_16, align 8
+  store i64 1, ptr %local_17, align 8
+  %add_src_0 = load i64, ptr %local_16, align 8
+  %add_src_1 = load i64, ptr %local_17, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_3
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_3
+  store i64 %add_dst, ptr %local_18, align 8
+  %load_store_tmp13 = load i64, ptr %local_18, align 8
+  store i64 %load_store_tmp13, ptr %local_1, align 8
+  br label %bb_5
+
+bb_0:                                             ; preds = %bb_5
+  %load_store_tmp14 = load { ptr, i64, i64 }, ptr %local_0, align 8
+  store { ptr, i64, i64 } %load_store_tmp14, ptr %local_19__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_19__bytes, align 8
+  %insert_0 = insertvalue %struct.ascii__String undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.ascii__String %insert_0, ptr %local_20, align 8
+  %call_arg_015 = load %struct.ascii__String, ptr %local_20, align 8
+  %retval16 = call %struct.option__Option_ascii__String_ @"0000000000000001_option_some_BHfbJFjPbpZvwr"(%struct.ascii__String %call_arg_015)
+  store %struct.option__Option_ascii__String_ %retval16, ptr %local_21, align 8
+  %retval17 = load %struct.option__Option_ascii__String_, ptr %local_21, align 8
+  ret %struct.option__Option_ascii__String_ %retval17
+}
+
+define i1 @"0000000000000001_ascii_is_valid_char_DoZuGpdUuUxshB"(i8 %0) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca i1, align 1
+  store i8 %0, ptr %local_0, align 1
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_1, align 1
+  store i8 127, ptr %local_2, align 1
+  %le_src_0 = load i8, ptr %local_1, align 1
+  %le_src_1 = load i8, ptr %local_2, align 1
+  %le_dst = icmp ule i8 %le_src_0, %le_src_1
+  store i1 %le_dst, ptr %local_3, align 1
+  %retval = load i1, ptr %local_3, align 1
+  ret i1 %retval
+}
+
+define private %struct.option__Option_ascii__String_ @"0000000000000001_option_none_EQcMcKEA3CrrkT"() {
+entry:
+  %local_0__vec = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca %struct.option__Option_ascii__String_, align 8
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_ascii__String)
+  store { ptr, i64, i64 } %retval, ptr %local_0__vec, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_0__vec, align 8
+  %insert_0 = insertvalue %struct.option__Option_ascii__String_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.option__Option_ascii__String_ %insert_0, ptr %local_1, align 8
+  %retval1 = load %struct.option__Option_ascii__String_, ptr %local_1, align 8
+  ret %struct.option__Option_ascii__String_ %retval1
+}
+
+declare { ptr, i64, i64 } @move_native_vector_empty(ptr)
+
+define private %struct.option__Option_ascii__String_ @"0000000000000001_option_some_BHfbJFjPbpZvwr"(%struct.ascii__String %0) {
+entry:
+  %local_0 = alloca %struct.ascii__String, align 8
+  %local_1 = alloca %struct.ascii__String, align 8
+  %local_2__vec = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca %struct.option__Option_ascii__String_, align 8
+  store %struct.ascii__String %0, ptr %local_0, align 8
+  %call_arg_0 = load %struct.ascii__String, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000001_vector_singleton_9ZbC7UpW4NYMiM"(%struct.ascii__String %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_2__vec, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_2__vec, align 8
+  %insert_0 = insertvalue %struct.option__Option_ascii__String_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.option__Option_ascii__String_ %insert_0, ptr %local_3, align 8
+  %retval1 = load %struct.option__Option_ascii__String_, ptr %local_3, align 8
+  ret %struct.option__Option_ascii__String_ %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000001_vector_singleton_9ZbC7UpW4NYMiM"(%struct.ascii__String %0) {
+entry:
+  %local_0 = alloca %struct.ascii__String, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca %struct.ascii__String, align 8
+  %local_5 = alloca { ptr, i64, i64 }, align 8
+  store %struct.ascii__String %0, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_ascii__String)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_2, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_3, align 8
+  %loaded_alloca = load ptr, ptr %local_3, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_ascii__String, ptr %loaded_alloca, ptr %local_0)
+  %load_store_tmp1 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp1, ptr %local_5, align 8
+  %retval2 = load { ptr, i64, i64 }, ptr %local_5, align 8
+  ret { ptr, i64, i64 } %retval2
+}
+
+declare void @move_native_vector_push_back(ptr, ptr, ptr)
+
+define private i1 @"0000000000000001_option_is_some_3HbPGsdEGsnX7R"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2__vec = alloca ptr, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i1, align 1
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %tmp = load ptr, ptr %local_1, align 8
+  %fld_ref = getelementptr inbounds %struct.option__Option_ascii__String_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_2__vec, align 8
+  %call_arg_0 = load ptr, ptr %local_2__vec, align 8
+  %retval = call i1 @"0000000000000001_vector_is_empty_5wcrapXJYC1zTv"(ptr %call_arg_0)
+  store i1 %retval, ptr %local_3, align 1
+  %not_src = load i1, ptr %local_3, align 1
+  %not_dst = xor i1 %not_src, true
+  store i1 %not_dst, ptr %local_4, align 1
+  %retval1 = load i1, ptr %local_4, align 1
+  ret i1 %retval1
+}
+
+define private i1 @"0000000000000001_vector_is_empty_5wcrapXJYC1zTv"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca i1, align 1
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_ascii__String, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_2, align 8
+  store i64 0, ptr %local_3, align 8
+  %eq_src_0 = load i64, ptr %local_2, align 8
+  %eq_src_1 = load i64, ptr %local_3, align 8
+  %eq_dst = icmp eq i64 %eq_src_0, %eq_src_1
+  store i1 %eq_dst, ptr %local_4, align 1
+  %retval1 = load i1, ptr %local_4, align 1
+  ret i1 %retval1
+}
+
+define private %struct.ascii__String @"0000000000000001_option_destroy_some_6qpnBkqx6R338H"(%struct.option__Option_ascii__String_ %0) {
+entry:
+  %local_0 = alloca %struct.option__Option_ascii__String_, align 8
+  %local_1 = alloca %struct.ascii__String, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca %struct.option__Option_ascii__String_, align 8
+  %local_7__vec = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca ptr, align 8
+  %local_9 = alloca %struct.ascii__String, align 8
+  %local_10 = alloca { ptr, i64, i64 }, align 8
+  %local_11 = alloca %struct.ascii__String, align 8
+  store %struct.option__Option_ascii__String_ %0, ptr %local_0, align 8
+  store ptr %local_0, ptr %local_3, align 8
+  %call_arg_0 = load ptr, ptr %local_3, align 8
+  %retval = call i1 @"0000000000000001_option_is_some_3HbPGsdEGsnX7R"(ptr %call_arg_0)
+  store i1 %retval, ptr %local_4, align 1
+  %cnd = load i1, ptr %local_4, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i64 262145, ptr %local_5, align 8
+  %call_arg_01 = load i64, ptr %local_5, align 8
+  call void @move_rt_abort(i64 %call_arg_01)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  %srcval = load %struct.option__Option_ascii__String_, ptr %local_0, align 8
+  %ext_0 = extractvalue %struct.option__Option_ascii__String_ %srcval, 0
+  store { ptr, i64, i64 } %ext_0, ptr %local_7__vec, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_7__vec, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_2, align 8
+  store ptr %local_2, ptr %local_8, align 8
+  %loaded_alloca = load ptr, ptr %local_8, align 8
+  call void @move_native_vector_pop_back(ptr @__move_rttydesc_ascii__String, ptr %loaded_alloca, ptr %local_9)
+  %load_store_tmp2 = load %struct.ascii__String, ptr %local_9, align 8
+  store %struct.ascii__String %load_store_tmp2, ptr %local_1, align 8
+  %load_store_tmp3 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  store { ptr, i64, i64 } %load_store_tmp3, ptr %local_10, align 8
+  call void @move_native_vector_destroy_empty(ptr @__move_rttydesc_ascii__String, ptr %local_10)
+  %retval4 = load %struct.ascii__String, ptr %local_1, align 8
+  ret %struct.ascii__String %retval4
+}
+
+declare void @move_native_vector_pop_back(ptr, ptr, ptr)
+
+declare void @move_native_vector_destroy_empty(ptr, ptr)
+
+define i8 @"0000000000000001_ascii_byte_9HEHdTuDV4YLBd"(%struct.ascii__Char %0) {
+entry:
+  %local_0 = alloca %struct.ascii__Char, align 8
+  %local_1 = alloca %struct.ascii__Char, align 8
+  %local_2__byte = alloca i8, align 1
+  store %struct.ascii__Char %0, ptr %local_0, align 1
+  %srcval = load %struct.ascii__Char, ptr %local_0, align 1
+  %ext_0 = extractvalue %struct.ascii__Char %srcval, 0
+  store i8 %ext_0, ptr %local_2__byte, align 1
+  %retval = load i8, ptr %local_2__byte, align 1
+  ret i8 %retval
+}
+
+define %struct.ascii__Char @"0000000000000001_ascii_char_6G2K63pqs2kYAg"(i8 %0) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i1, align 1
+  %local_3 = alloca i64, align 8
+  %local_4__byte = alloca i8, align 1
+  %local_5 = alloca %struct.ascii__Char, align 8
+  store i8 %0, ptr %local_0, align 1
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_1, align 1
+  %call_arg_0 = load i8, ptr %local_1, align 1
+  %retval = call i1 @"0000000000000001_ascii_is_valid_char_DoZuGpdUuUxshB"(i8 %call_arg_0)
+  store i1 %retval, ptr %local_2, align 1
+  %cnd = load i1, ptr %local_2, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i64 65536, ptr %local_3, align 8
+  %call_arg_01 = load i64, ptr %local_3, align 8
+  call void @move_rt_abort(i64 %call_arg_01)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  %load_store_tmp2 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp2, ptr %local_4__byte, align 1
+  %fv.0 = load i8, ptr %local_4__byte, align 1
+  %insert_0 = insertvalue %struct.ascii__Char undef, i8 %fv.0, 0
+  store %struct.ascii__Char %insert_0, ptr %local_5, align 1
+  %retval3 = load %struct.ascii__Char, ptr %local_5, align 1
+  ret %struct.ascii__Char %retval3
+}
+
+define { ptr, i64, i64 } @"0000000000000001_ascii_into_bytes_FDcNSCdomW72yz"(%struct.ascii__String %0) {
+entry:
+  %local_0 = alloca %struct.ascii__String, align 8
+  %local_1 = alloca %struct.ascii__String, align 8
+  %local_2__bytes = alloca { ptr, i64, i64 }, align 8
+  store %struct.ascii__String %0, ptr %local_0, align 8
+  %srcval = load %struct.ascii__String, ptr %local_0, align 8
+  %ext_0 = extractvalue %struct.ascii__String %srcval, 0
+  store { ptr, i64, i64 } %ext_0, ptr %local_2__bytes, align 8
+  %retval = load { ptr, i64, i64 }, ptr %local_2__bytes, align 8
+  ret { ptr, i64, i64 } %retval
+}
+
+define %struct.ascii__Char @"0000000000000001_ascii_pop_char_6V1swsCdrbAvsn"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2__bytes = alloca ptr, align 8
+  %local_3__byte = alloca i8, align 1
+  %local_4 = alloca %struct.ascii__Char, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %tmp = load ptr, ptr %local_1, align 8
+  %fld_ref = getelementptr inbounds %struct.ascii__String, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_2__bytes, align 8
+  %loaded_alloca = load ptr, ptr %local_2__bytes, align 8
+  call void @move_native_vector_pop_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca, ptr %local_3__byte)
+  %fv.0 = load i8, ptr %local_3__byte, align 1
+  %insert_0 = insertvalue %struct.ascii__Char undef, i8 %fv.0, 0
+  store %struct.ascii__Char %insert_0, ptr %local_4, align 1
+  %retval = load %struct.ascii__Char, ptr %local_4, align 1
+  ret %struct.ascii__Char %retval
+}
+
+define void @"0000000000000001_ascii_push_char_4WMMox4A995zde"(ptr noalias nonnull %0, %struct.ascii__Char %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca %struct.ascii__Char, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3__bytes = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5__byte = alloca ptr, align 8
+  %local_6 = alloca i8, align 1
+  store ptr %0, ptr %local_0, align 8
+  store %struct.ascii__Char %1, ptr %local_1, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_2, align 8
+  %tmp = load ptr, ptr %local_2, align 8
+  %fld_ref = getelementptr inbounds %struct.ascii__String, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_3__bytes, align 8
+  store ptr %local_1, ptr %local_4, align 8
+  %tmp1 = load ptr, ptr %local_4, align 8
+  %fld_ref2 = getelementptr inbounds %struct.ascii__Char, ptr %tmp1, i32 0, i32 0
+  store ptr %fld_ref2, ptr %local_5__byte, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_5__byte, align 8
+  %load_deref_store_tmp2 = load i8, ptr %load_deref_store_tmp1, align 1
+  store i8 %load_deref_store_tmp2, ptr %local_6, align 1
+  %loaded_alloca = load ptr, ptr %local_3__bytes, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca, ptr %local_6)
+  ret void
+}
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)
+
+; Function Attrs: cold noreturn
+declare void @move_rt_abort(i64) #0
+
+attributes #0 = { cold noreturn }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x1__bcs.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x1__bcs.ll.expected
@@ -1,0 +1,30 @@
+; ModuleID = '0x1__bcs'
+source_filename = "../../../../../../../crates/sui-framework/packages/move-stdlib/sources/bcs.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define void @"0000000000000001_bcs_unit_test_poiso_4EamySTKbGf1At"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+declare { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr, ptr)
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x1__hash.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x1__hash.ll.expected
@@ -1,0 +1,32 @@
+; ModuleID = '0x1__hash'
+source_filename = "../../../../../../../crates/sui-framework/packages/move-stdlib/sources/hash.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define void @"0000000000000001_hash_unit_test_poiso_4wx61fBNpDhykC"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+declare { ptr, i64, i64 } @move_native_hash_sha2_256(ptr)
+
+declare { ptr, i64, i64 } @move_native_hash_sha3_256(ptr)
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x1__option.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x1__option.ll.expected
@@ -1,0 +1,28 @@
+; ModuleID = '0x1__option'
+source_filename = "../../../../../../../crates/sui-framework/packages/move-stdlib/sources/option.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define void @"0000000000000001_option_unit_test_poiso_EP3nukEuKMz1wh"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x1__string.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x1__string.ll.expected
@@ -1,0 +1,938 @@
+; ModuleID = '0x1__string'
+source_filename = "../../../../../../../crates/sui-framework/packages/move-stdlib/sources/string.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+%struct.string__String = type { { ptr, i64, i64 } }
+%struct.ascii__String = type { { ptr, i64, i64 } }
+%struct.option__Option_string__String_ = type { { ptr, i64, i64 } }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+@__move_rttydesc_u8 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u8_name, i64 2 }, i64 2, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u8_name = private unnamed_addr constant [2 x i8] c"u8"
+@__move_rttydesc_string__String = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_string__String_name, i64 80 }, i64 11, ptr @__move_rttydesc_string__String_info }
+@__move_rttydesc_string__String_name = private unnamed_addr constant [80 x i8] c"0000000000000000000000000000000000000000000000000000000000000001::string::String"
+@__move_rttydesc_vector_u8__name = private unnamed_addr constant [10 x i8] c"vector<u8>"
+@__move_rttydesc_vector_u8__info = private unnamed_addr constant { ptr } { ptr @__move_rttydesc_u8 }
+@0 = private unnamed_addr constant [5 x i8] c"bytes"
+@s_fld_array = private unnamed_addr constant [1 x { %__move_rt_type, i64, { ptr, i64 } }] [{ %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_u8__name, i64 10 }, i64 10, ptr @__move_rttydesc_vector_u8__info }, i64 0, { ptr, i64 } { ptr @0, i64 5 } }]
+@__move_rttydesc_string__String_info = private unnamed_addr constant { ptr, i64, i64, i64 } { ptr @s_fld_array, i64 1, i64 24, i64 8 }
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define void @"0000000000000001_string_unit_test_poiso_2MTPKgM8Q5KsZh"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+define void @"0000000000000001_string_append_DQe8grw7AGnkHc"(ptr noalias nonnull %0, %struct.string__String %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca %struct.string__String, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3__bytes = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  store %struct.string__String %1, ptr %local_1, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_2, align 8
+  %tmp = load ptr, ptr %local_2, align 8
+  %fld_ref = getelementptr inbounds %struct.string__String, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_3__bytes, align 8
+  store ptr %local_1, ptr %local_4, align 8
+  %tmp1 = load ptr, ptr %local_4, align 8
+  %fld_ref2 = getelementptr inbounds %struct.string__String, ptr %tmp1, i32 0, i32 0
+  store ptr %fld_ref2, ptr %local_5__bytes, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_5__bytes, align 8
+  %load_deref_store_tmp2 = load { ptr, i64, i64 }, ptr %load_deref_store_tmp1, align 8
+  store { ptr, i64, i64 } %load_deref_store_tmp2, ptr %local_6, align 8
+  %call_arg_0 = load ptr, ptr %local_3__bytes, align 8
+  %call_arg_1 = load { ptr, i64, i64 }, ptr %local_6, align 8
+  call void @"0000000000000001_vector_append_9dqoPGavEhpvk5"(ptr %call_arg_0, { ptr, i64, i64 } %call_arg_1)
+  ret void
+}
+
+define private void @"0000000000000001_vector_append_9dqoPGavEhpvk5"(ptr noalias nonnull %0, { ptr, i64, i64 } %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca i1, align 1
+  %local_6 = alloca ptr, align 8
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca i8, align 1
+  %local_9 = alloca ptr, align 8
+  %local_10 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  store { ptr, i64, i64 } %1, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_2, align 8
+  %call_arg_0 = load ptr, ptr %local_2, align 8
+  call void @"0000000000000001_vector_reverse_DYV9motnmmM5cs"(ptr %call_arg_0)
+  br label %bb_3
+
+bb_3:                                             ; preds = %bb_2, %entry
+  store ptr %local_1, ptr %local_3, align 8
+  %call_arg_01 = load ptr, ptr %local_3, align 8
+  %retval = call i1 @"0000000000000001_vector_is_empty_BrzErKu8hVV1SC"(ptr %call_arg_01)
+  store i1 %retval, ptr %local_4, align 1
+  %not_src = load i1, ptr %local_4, align 1
+  %not_dst = xor i1 %not_src, true
+  store i1 %not_dst, ptr %local_5, align 1
+  %cnd = load i1, ptr %local_5, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %bb_3
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_6, align 8
+  store ptr %local_1, ptr %local_7, align 8
+  %loaded_alloca = load ptr, ptr %local_7, align 8
+  call void @move_native_vector_pop_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca, ptr %local_8)
+  %loaded_alloca2 = load ptr, ptr %local_6, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca2, ptr %local_8)
+  br label %bb_3
+
+bb_0:                                             ; preds = %bb_3
+  %load_store_tmp3 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp3, ptr %local_9, align 8
+  %load_store_tmp4 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp4, ptr %local_10, align 8
+  call void @move_native_vector_destroy_empty(ptr @__move_rttydesc_u8, ptr %local_10)
+  ret void
+}
+
+define private void @"0000000000000001_vector_reverse_DYV9motnmmM5cs"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca ptr, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i1, align 1
+  %local_10 = alloca ptr, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca i64, align 8
+  %local_13 = alloca i64, align 8
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca i1, align 1
+  %local_18 = alloca ptr, align 8
+  %local_19 = alloca i64, align 8
+  %local_20 = alloca i64, align 8
+  %local_21 = alloca i64, align 8
+  %local_22 = alloca i64, align 8
+  %local_23 = alloca i64, align 8
+  %local_24 = alloca i64, align 8
+  %local_25 = alloca i64, align 8
+  %local_26 = alloca i64, align 8
+  %local_27 = alloca ptr, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_4, align 8
+  %load_store_tmp1 = load ptr, ptr %local_4, align 8
+  store ptr %load_store_tmp1, ptr %local_5, align 8
+  %loaded_alloca = load ptr, ptr %local_5, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_6, align 8
+  %load_store_tmp2 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp2, ptr %local_3, align 8
+  %load_store_tmp3 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp3, ptr %local_7, align 8
+  store i64 0, ptr %local_8, align 8
+  %eq_src_0 = load i64, ptr %local_7, align 8
+  %eq_src_1 = load i64, ptr %local_8, align 8
+  %eq_dst = icmp eq i64 %eq_src_0, %eq_src_1
+  store i1 %eq_dst, ptr %local_9, align 1
+  %cnd = load i1, ptr %local_9, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  %load_store_tmp4 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp4, ptr %local_10, align 8
+  ret void
+
+bb_0:                                             ; preds = %entry
+  store i64 0, ptr %local_11, align 8
+  %load_store_tmp5 = load i64, ptr %local_11, align 8
+  store i64 %load_store_tmp5, ptr %local_2, align 8
+  %load_store_tmp6 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp6, ptr %local_12, align 8
+  store i64 1, ptr %local_13, align 8
+  %sub_src_0 = load i64, ptr %local_12, align 8
+  %sub_src_1 = load i64, ptr %local_13, align 8
+  %sub_dst = sub i64 %sub_src_0, %sub_src_1
+  %ovfcond = icmp ugt i64 %sub_dst, %sub_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_0
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_0
+  store i64 %sub_dst, ptr %local_14, align 8
+  %load_store_tmp7 = load i64, ptr %local_14, align 8
+  store i64 %load_store_tmp7, ptr %local_1, align 8
+  br label %bb_5
+
+bb_5:                                             ; preds = %join_bb28, %join_bb
+  %load_store_tmp8 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp8, ptr %local_15, align 8
+  %load_store_tmp9 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp9, ptr %local_16, align 8
+  %lt_src_0 = load i64, ptr %local_15, align 8
+  %lt_src_1 = load i64, ptr %local_16, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_17, align 1
+  %cnd10 = load i1, ptr %local_17, align 1
+  br i1 %cnd10, label %bb_3, label %bb_2
+
+bb_3:                                             ; preds = %bb_5
+  br label %bb_4
+
+bb_4:                                             ; preds = %bb_3
+  %load_store_tmp11 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp11, ptr %local_18, align 8
+  %load_store_tmp12 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp12, ptr %local_19, align 8
+  %load_store_tmp13 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp13, ptr %local_20, align 8
+  %loaded_alloca14 = load ptr, ptr %local_18, align 8
+  %loaded_alloca15 = load i64, ptr %local_19, align 8
+  %loaded_alloca16 = load i64, ptr %local_20, align 8
+  call void @move_native_vector_swap(ptr @__move_rttydesc_u8, ptr %loaded_alloca14, i64 %loaded_alloca15, i64 %loaded_alloca16)
+  %load_store_tmp17 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp17, ptr %local_21, align 8
+  store i64 1, ptr %local_22, align 8
+  %add_src_0 = load i64, ptr %local_21, align 8
+  %add_src_1 = load i64, ptr %local_22, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond18 = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond18, label %then_bb19, label %join_bb20
+
+then_bb19:                                        ; preds = %bb_4
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb20:                                        ; preds = %bb_4
+  store i64 %add_dst, ptr %local_23, align 8
+  %load_store_tmp21 = load i64, ptr %local_23, align 8
+  store i64 %load_store_tmp21, ptr %local_2, align 8
+  %load_store_tmp22 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp22, ptr %local_24, align 8
+  store i64 1, ptr %local_25, align 8
+  %sub_src_023 = load i64, ptr %local_24, align 8
+  %sub_src_124 = load i64, ptr %local_25, align 8
+  %sub_dst25 = sub i64 %sub_src_023, %sub_src_124
+  %ovfcond26 = icmp ugt i64 %sub_dst25, %sub_src_023
+  br i1 %ovfcond26, label %then_bb27, label %join_bb28
+
+then_bb27:                                        ; preds = %join_bb20
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb28:                                        ; preds = %join_bb20
+  store i64 %sub_dst25, ptr %local_26, align 8
+  %load_store_tmp29 = load i64, ptr %local_26, align 8
+  store i64 %load_store_tmp29, ptr %local_1, align 8
+  br label %bb_5
+
+bb_2:                                             ; preds = %bb_5
+  %load_store_tmp30 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp30, ptr %local_27, align 8
+  ret void
+}
+
+declare i64 @move_native_vector_length(ptr, ptr)
+
+declare void @move_native_vector_swap(ptr, ptr, i64, i64)
+
+define private i1 @"0000000000000001_vector_is_empty_BrzErKu8hVV1SC"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca i1, align 1
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_2, align 8
+  store i64 0, ptr %local_3, align 8
+  %eq_src_0 = load i64, ptr %local_2, align 8
+  %eq_src_1 = load i64, ptr %local_3, align 8
+  %eq_dst = icmp eq i64 %eq_src_0, %eq_src_1
+  store i1 %eq_dst, ptr %local_4, align 1
+  %retval1 = load i1, ptr %local_4, align 1
+  ret i1 %retval1
+}
+
+declare void @move_native_vector_pop_back(ptr, ptr, ptr)
+
+declare void @move_native_vector_push_back(ptr, ptr, ptr)
+
+declare void @move_native_vector_destroy_empty(ptr, ptr)
+
+define i64 @"0000000000000001_string_index_of_7QkiC8witPS2sP"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3__bytes = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca i64, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_2, align 8
+  %tmp = load ptr, ptr %local_2, align 8
+  %fld_ref = getelementptr inbounds %struct.string__String, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_3__bytes, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp2 = load ptr, ptr %local_4, align 8
+  %fld_ref3 = getelementptr inbounds %struct.string__String, ptr %tmp2, i32 0, i32 0
+  store ptr %fld_ref3, ptr %local_5__bytes, align 8
+  %loaded_alloca = load ptr, ptr %local_3__bytes, align 8
+  %loaded_alloca4 = load ptr, ptr %local_5__bytes, align 8
+  %retval = call i64 @move_native_string_internal_index_of(ptr %loaded_alloca, ptr %loaded_alloca4)
+  store i64 %retval, ptr %local_6, align 8
+  %retval5 = load i64, ptr %local_6, align 8
+  ret i64 %retval5
+}
+
+declare i64 @move_native_string_internal_index_of(ptr, ptr)
+
+define void @"0000000000000001_string_insert_Eqvs2kAUgYa7K7"(ptr noalias nonnull %0, i64 %1, %struct.string__String %2) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca %struct.string__String, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i64, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca %struct.string__String, align 8
+  %local_9 = alloca %struct.string__String, align 8
+  %local_10 = alloca i64, align 8
+  %local_11 = alloca ptr, align 8
+  %local_12__bytes = alloca ptr, align 8
+  %local_13 = alloca i64, align 8
+  %local_14 = alloca ptr, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca i1, align 1
+  %local_17 = alloca ptr, align 8
+  %local_18 = alloca i64, align 8
+  %local_19 = alloca i1, align 1
+  %local_20 = alloca ptr, align 8
+  %local_21 = alloca i1, align 1
+  %local_22 = alloca i1, align 1
+  %local_23 = alloca ptr, align 8
+  %local_24 = alloca i64, align 8
+  %local_25 = alloca ptr, align 8
+  %local_26 = alloca ptr, align 8
+  %local_27 = alloca i64, align 8
+  %local_28 = alloca ptr, align 8
+  %local_29 = alloca i64, align 8
+  %local_30 = alloca ptr, align 8
+  %local_31 = alloca i64, align 8
+  %local_32 = alloca i64, align 8
+  %local_33 = alloca %struct.string__String, align 8
+  %local_34 = alloca ptr, align 8
+  %local_35 = alloca i64, align 8
+  %local_36 = alloca i64, align 8
+  %local_37 = alloca ptr, align 8
+  %local_38 = alloca i64, align 8
+  %local_39 = alloca i64, align 8
+  %local_40 = alloca %struct.string__String, align 8
+  %local_41 = alloca ptr, align 8
+  %local_42 = alloca %struct.string__String, align 8
+  %local_43 = alloca ptr, align 8
+  %local_44 = alloca %struct.string__String, align 8
+  %local_45 = alloca %struct.string__String, align 8
+  %local_46 = alloca ptr, align 8
+  store ptr %0, ptr %local_0, align 8
+  store i64 %1, ptr %local_1, align 8
+  store %struct.string__String %2, ptr %local_2, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_11, align 8
+  %tmp = load ptr, ptr %local_11, align 8
+  %fld_ref = getelementptr inbounds %struct.string__String, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_12__bytes, align 8
+  %load_store_tmp1 = load ptr, ptr %local_12__bytes, align 8
+  store ptr %load_store_tmp1, ptr %local_7, align 8
+  %load_store_tmp2 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp2, ptr %local_13, align 8
+  %load_store_tmp3 = load ptr, ptr %local_7, align 8
+  store ptr %load_store_tmp3, ptr %local_14, align 8
+  %loaded_alloca = load ptr, ptr %local_14, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_15, align 8
+  %le_src_0 = load i64, ptr %local_13, align 8
+  %le_src_1 = load i64, ptr %local_15, align 8
+  %le_dst = icmp ule i64 %le_src_0, %le_src_1
+  store i1 %le_dst, ptr %local_16, align 1
+  %cnd = load i1, ptr %local_16, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  %load_store_tmp4 = load ptr, ptr %local_7, align 8
+  store ptr %load_store_tmp4, ptr %local_17, align 8
+  %load_store_tmp5 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp5, ptr %local_18, align 8
+  %loaded_alloca6 = load ptr, ptr %local_17, align 8
+  %loaded_alloca7 = load i64, ptr %local_18, align 8
+  %retval8 = call i1 @move_native_string_internal_is_char_boundary(ptr %loaded_alloca6, i64 %loaded_alloca7)
+  store i1 %retval8, ptr %local_19, align 1
+  %load_store_tmp9 = load i1, ptr %local_19, align 1
+  store i1 %load_store_tmp9, ptr %local_3, align 1
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp10 = load ptr, ptr %local_7, align 8
+  store ptr %load_store_tmp10, ptr %local_20, align 8
+  store i1 false, ptr %local_21, align 1
+  %load_store_tmp11 = load i1, ptr %local_21, align 1
+  store i1 %load_store_tmp11, ptr %local_3, align 1
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_0, %bb_1
+  %load_store_tmp12 = load i1, ptr %local_3, align 1
+  store i1 %load_store_tmp12, ptr %local_22, align 1
+  %cnd13 = load i1, ptr %local_22, align 1
+  br i1 %cnd13, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  %load_store_tmp14 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp14, ptr %local_23, align 8
+  store i64 2, ptr %local_24, align 8
+  %call_arg_0 = load i64, ptr %local_24, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_5:                                             ; preds = %bb_4
+  %load_store_tmp15 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp15, ptr %local_25, align 8
+  %load_store_tmp16 = load ptr, ptr %local_25, align 8
+  store ptr %load_store_tmp16, ptr %local_26, align 8
+  %call_arg_017 = load ptr, ptr %local_26, align 8
+  %retval18 = call i64 @"0000000000000001_string_length_E7W2v3PBGDje29"(ptr %call_arg_017)
+  store i64 %retval18, ptr %local_27, align 8
+  %load_store_tmp19 = load i64, ptr %local_27, align 8
+  store i64 %load_store_tmp19, ptr %local_10, align 8
+  %load_store_tmp20 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp20, ptr %local_28, align 8
+  %load_store_tmp21 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp21, ptr %local_29, align 8
+  %load_store_tmp22 = load i64, ptr %local_29, align 8
+  store i64 %load_store_tmp22, ptr %local_4, align 8
+  %load_store_tmp23 = load ptr, ptr %local_28, align 8
+  store ptr %load_store_tmp23, ptr %local_30, align 8
+  store i64 0, ptr %local_31, align 8
+  %load_store_tmp24 = load i64, ptr %local_4, align 8
+  store i64 %load_store_tmp24, ptr %local_32, align 8
+  %call_arg_025 = load ptr, ptr %local_30, align 8
+  %call_arg_1 = load i64, ptr %local_31, align 8
+  %call_arg_2 = load i64, ptr %local_32, align 8
+  %retval26 = call %struct.string__String @"0000000000000001_string_sub_string_2bURZha8gEy1QH"(ptr %call_arg_025, i64 %call_arg_1, i64 %call_arg_2)
+  store %struct.string__String %retval26, ptr %local_33, align 8
+  %load_store_tmp27 = load %struct.string__String, ptr %local_33, align 8
+  store %struct.string__String %load_store_tmp27, ptr %local_9, align 8
+  %load_store_tmp28 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp28, ptr %local_34, align 8
+  %load_store_tmp29 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp29, ptr %local_35, align 8
+  %load_store_tmp30 = load i64, ptr %local_10, align 8
+  store i64 %load_store_tmp30, ptr %local_36, align 8
+  %load_store_tmp31 = load i64, ptr %local_36, align 8
+  store i64 %load_store_tmp31, ptr %local_6, align 8
+  %load_store_tmp32 = load i64, ptr %local_35, align 8
+  store i64 %load_store_tmp32, ptr %local_5, align 8
+  %load_store_tmp33 = load ptr, ptr %local_34, align 8
+  store ptr %load_store_tmp33, ptr %local_37, align 8
+  %load_store_tmp34 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp34, ptr %local_38, align 8
+  %load_store_tmp35 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp35, ptr %local_39, align 8
+  %call_arg_036 = load ptr, ptr %local_37, align 8
+  %call_arg_137 = load i64, ptr %local_38, align 8
+  %call_arg_238 = load i64, ptr %local_39, align 8
+  %retval39 = call %struct.string__String @"0000000000000001_string_sub_string_2bURZha8gEy1QH"(ptr %call_arg_036, i64 %call_arg_137, i64 %call_arg_238)
+  store %struct.string__String %retval39, ptr %local_40, align 8
+  %load_store_tmp40 = load %struct.string__String, ptr %local_40, align 8
+  store %struct.string__String %load_store_tmp40, ptr %local_8, align 8
+  store ptr %local_9, ptr %local_41, align 8
+  %call_arg_041 = load ptr, ptr %local_41, align 8
+  %call_arg_142 = load %struct.string__String, ptr %local_2, align 8
+  call void @"0000000000000001_string_append_DQe8grw7AGnkHc"(ptr %call_arg_041, %struct.string__String %call_arg_142)
+  store ptr %local_9, ptr %local_43, align 8
+  %call_arg_043 = load ptr, ptr %local_43, align 8
+  %call_arg_144 = load %struct.string__String, ptr %local_8, align 8
+  call void @"0000000000000001_string_append_DQe8grw7AGnkHc"(ptr %call_arg_043, %struct.string__String %call_arg_144)
+  %load_store_tmp45 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp45, ptr %local_46, align 8
+  %load_store_ref_src = load %struct.string__String, ptr %local_9, align 8
+  %load_store_ref_dst_ptr = load ptr, ptr %local_46, align 8
+  store %struct.string__String %load_store_ref_src, ptr %load_store_ref_dst_ptr, align 8
+  ret void
+}
+
+declare i1 @move_native_string_internal_is_char_boundary(ptr, i64)
+
+define i64 @"0000000000000001_string_length_E7W2v3PBGDje29"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2__bytes = alloca ptr, align 8
+  %local_3 = alloca i64, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %tmp = load ptr, ptr %local_1, align 8
+  %fld_ref = getelementptr inbounds %struct.string__String, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_2__bytes, align 8
+  %loaded_alloca = load ptr, ptr %local_2__bytes, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_3, align 8
+  %retval1 = load i64, ptr %local_3, align 8
+  ret i64 %retval1
+}
+
+define %struct.string__String @"0000000000000001_string_sub_string_2bURZha8gEy1QH"(ptr nonnull readonly %0, i64 %1, i64 %2) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca i1, align 1
+  %local_6 = alloca ptr, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca ptr, align 8
+  %local_9__bytes = alloca ptr, align 8
+  %local_10 = alloca ptr, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca i64, align 8
+  %local_13 = alloca i64, align 8
+  %local_14 = alloca i1, align 1
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca i1, align 1
+  %local_18 = alloca i1, align 1
+  %local_19 = alloca i1, align 1
+  %local_20 = alloca ptr, align 8
+  %local_21 = alloca i64, align 8
+  %local_22 = alloca i1, align 1
+  %local_23 = alloca i1, align 1
+  %local_24 = alloca i1, align 1
+  %local_25 = alloca ptr, align 8
+  %local_26 = alloca i64, align 8
+  %local_27 = alloca i1, align 1
+  %local_28 = alloca i1, align 1
+  %local_29 = alloca i1, align 1
+  %local_30 = alloca ptr, align 8
+  %local_31 = alloca i64, align 8
+  %local_32 = alloca ptr, align 8
+  %local_33 = alloca i64, align 8
+  %local_34 = alloca i64, align 8
+  %local_35__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_36 = alloca %struct.string__String, align 8
+  store ptr %0, ptr %local_0, align 8
+  store i64 %1, ptr %local_1, align 8
+  store i64 %2, ptr %local_2, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_8, align 8
+  %tmp = load ptr, ptr %local_8, align 8
+  %fld_ref = getelementptr inbounds %struct.string__String, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_9__bytes, align 8
+  %load_store_tmp1 = load ptr, ptr %local_9__bytes, align 8
+  store ptr %load_store_tmp1, ptr %local_6, align 8
+  %load_store_tmp2 = load ptr, ptr %local_6, align 8
+  store ptr %load_store_tmp2, ptr %local_10, align 8
+  %loaded_alloca = load ptr, ptr %local_10, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_11, align 8
+  %load_store_tmp3 = load i64, ptr %local_11, align 8
+  store i64 %load_store_tmp3, ptr %local_7, align 8
+  %load_store_tmp4 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp4, ptr %local_12, align 8
+  %load_store_tmp5 = load i64, ptr %local_7, align 8
+  store i64 %load_store_tmp5, ptr %local_13, align 8
+  %le_src_0 = load i64, ptr %local_12, align 8
+  %le_src_1 = load i64, ptr %local_13, align 8
+  %le_dst = icmp ule i64 %le_src_0, %le_src_1
+  store i1 %le_dst, ptr %local_14, align 1
+  %cnd = load i1, ptr %local_14, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  %load_store_tmp6 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp6, ptr %local_15, align 8
+  %load_store_tmp7 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp7, ptr %local_16, align 8
+  %le_src_08 = load i64, ptr %local_15, align 8
+  %le_src_19 = load i64, ptr %local_16, align 8
+  %le_dst10 = icmp ule i64 %le_src_08, %le_src_19
+  store i1 %le_dst10, ptr %local_17, align 1
+  %load_store_tmp11 = load i1, ptr %local_17, align 1
+  store i1 %load_store_tmp11, ptr %local_3, align 1
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i1 false, ptr %local_18, align 1
+  %load_store_tmp12 = load i1, ptr %local_18, align 1
+  store i1 %load_store_tmp12, ptr %local_3, align 1
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_0, %bb_1
+  %load_store_tmp13 = load i1, ptr %local_3, align 1
+  store i1 %load_store_tmp13, ptr %local_19, align 1
+  %cnd14 = load i1, ptr %local_19, align 1
+  br i1 %cnd14, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  %load_store_tmp15 = load ptr, ptr %local_6, align 8
+  store ptr %load_store_tmp15, ptr %local_20, align 8
+  %load_store_tmp16 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp16, ptr %local_21, align 8
+  %loaded_alloca17 = load ptr, ptr %local_20, align 8
+  %loaded_alloca18 = load i64, ptr %local_21, align 8
+  %retval19 = call i1 @move_native_string_internal_is_char_boundary(ptr %loaded_alloca17, i64 %loaded_alloca18)
+  store i1 %retval19, ptr %local_22, align 1
+  %load_store_tmp20 = load i1, ptr %local_22, align 1
+  store i1 %load_store_tmp20, ptr %local_4, align 1
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  store i1 false, ptr %local_23, align 1
+  %load_store_tmp21 = load i1, ptr %local_23, align 1
+  store i1 %load_store_tmp21, ptr %local_4, align 1
+  br label %bb_5
+
+bb_5:                                             ; preds = %bb_3, %bb_4
+  %load_store_tmp22 = load i1, ptr %local_4, align 1
+  store i1 %load_store_tmp22, ptr %local_24, align 1
+  %cnd23 = load i1, ptr %local_24, align 1
+  br i1 %cnd23, label %bb_7, label %bb_6
+
+bb_7:                                             ; preds = %bb_5
+  %load_store_tmp24 = load ptr, ptr %local_6, align 8
+  store ptr %load_store_tmp24, ptr %local_25, align 8
+  %load_store_tmp25 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp25, ptr %local_26, align 8
+  %loaded_alloca26 = load ptr, ptr %local_25, align 8
+  %loaded_alloca27 = load i64, ptr %local_26, align 8
+  %retval28 = call i1 @move_native_string_internal_is_char_boundary(ptr %loaded_alloca26, i64 %loaded_alloca27)
+  store i1 %retval28, ptr %local_27, align 1
+  %load_store_tmp29 = load i1, ptr %local_27, align 1
+  store i1 %load_store_tmp29, ptr %local_5, align 1
+  br label %bb_8
+
+bb_6:                                             ; preds = %bb_5
+  store i1 false, ptr %local_28, align 1
+  %load_store_tmp30 = load i1, ptr %local_28, align 1
+  store i1 %load_store_tmp30, ptr %local_5, align 1
+  br label %bb_8
+
+bb_8:                                             ; preds = %bb_6, %bb_7
+  %load_store_tmp31 = load i1, ptr %local_5, align 1
+  store i1 %load_store_tmp31, ptr %local_29, align 1
+  %cnd32 = load i1, ptr %local_29, align 1
+  br i1 %cnd32, label %bb_10, label %bb_9
+
+bb_10:                                            ; preds = %bb_8
+  br label %bb_11
+
+bb_9:                                             ; preds = %bb_8
+  %load_store_tmp33 = load ptr, ptr %local_6, align 8
+  store ptr %load_store_tmp33, ptr %local_30, align 8
+  store i64 2, ptr %local_31, align 8
+  %call_arg_0 = load i64, ptr %local_31, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_11:                                            ; preds = %bb_10
+  %load_store_tmp34 = load ptr, ptr %local_6, align 8
+  store ptr %load_store_tmp34, ptr %local_32, align 8
+  %load_store_tmp35 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp35, ptr %local_33, align 8
+  %load_store_tmp36 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp36, ptr %local_34, align 8
+  %loaded_alloca37 = load ptr, ptr %local_32, align 8
+  %loaded_alloca38 = load i64, ptr %local_33, align 8
+  %loaded_alloca39 = load i64, ptr %local_34, align 8
+  %retval40 = call { ptr, i64, i64 } @move_native_string_internal_sub_string(ptr %loaded_alloca37, i64 %loaded_alloca38, i64 %loaded_alloca39)
+  store { ptr, i64, i64 } %retval40, ptr %local_35__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_35__bytes, align 8
+  %insert_0 = insertvalue %struct.string__String undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.string__String %insert_0, ptr %local_36, align 8
+  %retval41 = load %struct.string__String, ptr %local_36, align 8
+  ret %struct.string__String %retval41
+}
+
+declare { ptr, i64, i64 } @move_native_string_internal_sub_string(ptr, i64, i64)
+
+define i1 @"0000000000000001_string_is_empty_7SgPmUng9142UN"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2__bytes = alloca ptr, align 8
+  %local_3 = alloca i1, align 1
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %tmp = load ptr, ptr %local_1, align 8
+  %fld_ref = getelementptr inbounds %struct.string__String, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_2__bytes, align 8
+  %call_arg_0 = load ptr, ptr %local_2__bytes, align 8
+  %retval = call i1 @"0000000000000001_vector_is_empty_BrzErKu8hVV1SC"(ptr %call_arg_0)
+  store i1 %retval, ptr %local_3, align 1
+  %retval1 = load i1, ptr %local_3, align 1
+  ret i1 %retval1
+}
+
+define ptr @"0000000000000001_string_bytes_BCEq1G4JAYfFBc"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2__bytes = alloca ptr, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %tmp = load ptr, ptr %local_1, align 8
+  %fld_ref = getelementptr inbounds %struct.string__String, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_2__bytes, align 8
+  %retval = load ptr, ptr %local_2__bytes, align 8
+  ret ptr %retval
+}
+
+define void @"0000000000000001_string_append_utf8_HaK14brxmLbJBp"(ptr noalias nonnull %0, { ptr, i64, i64 } %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca { ptr, i64, i64 }, align 8
+  %local_4 = alloca %struct.string__String, align 8
+  store ptr %0, ptr %local_0, align 8
+  store { ptr, i64, i64 } %1, ptr %local_1, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_2, align 8
+  %load_store_tmp1 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp1, ptr %local_3, align 8
+  %call_arg_0 = load { ptr, i64, i64 }, ptr %local_3, align 8
+  %retval = call %struct.string__String @"0000000000000001_string_utf8_Fy6EqsEL4pdfgC"({ ptr, i64, i64 } %call_arg_0)
+  store %struct.string__String %retval, ptr %local_4, align 8
+  %call_arg_02 = load ptr, ptr %local_2, align 8
+  %call_arg_1 = load %struct.string__String, ptr %local_4, align 8
+  call void @"0000000000000001_string_append_DQe8grw7AGnkHc"(ptr %call_arg_02, %struct.string__String %call_arg_1)
+  ret void
+}
+
+define %struct.string__String @"0000000000000001_string_utf8_Fy6EqsEL4pdfgC"({ ptr, i64, i64 } %0) {
+entry:
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i1, align 1
+  %local_3 = alloca i64, align 8
+  %local_4__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_5 = alloca %struct.string__String, align 8
+  store { ptr, i64, i64 } %0, ptr %local_0, align 8
+  store ptr %local_0, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call i1 @move_native_string_internal_check_utf8(ptr %loaded_alloca)
+  store i1 %retval, ptr %local_2, align 1
+  %cnd = load i1, ptr %local_2, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i64 1, ptr %local_3, align 8
+  %call_arg_0 = load i64, ptr %local_3, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_0, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_4__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_4__bytes, align 8
+  %insert_0 = insertvalue %struct.string__String undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.string__String %insert_0, ptr %local_5, align 8
+  %retval1 = load %struct.string__String, ptr %local_5, align 8
+  ret %struct.string__String %retval1
+}
+
+declare i1 @move_native_string_internal_check_utf8(ptr)
+
+define %struct.string__String @"0000000000000001_string_from_ascii_231x8gDp4D9p4F"(%struct.ascii__String %0) {
+entry:
+  %local_0 = alloca %struct.ascii__String, align 8
+  %local_1 = alloca %struct.ascii__String, align 8
+  %local_2__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca %struct.string__String, align 8
+  store %struct.ascii__String %0, ptr %local_0, align 8
+  %call_arg_0 = load %struct.ascii__String, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000001_ascii_into_bytes_FDcNSCdomW72yz"(%struct.ascii__String %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_2__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_2__bytes, align 8
+  %insert_0 = insertvalue %struct.string__String undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.string__String %insert_0, ptr %local_3, align 8
+  %retval1 = load %struct.string__String, ptr %local_3, align 8
+  ret %struct.string__String %retval1
+}
+
+declare { ptr, i64, i64 } @"0000000000000001_ascii_into_bytes_FDcNSCdomW72yz"(%struct.ascii__String)
+
+define %struct.ascii__String @"0000000000000001_string_to_ascii_6WSfsLe3JUejhz"(%struct.string__String %0) {
+entry:
+  %local_0 = alloca %struct.string__String, align 8
+  %local_1 = alloca %struct.string__String, align 8
+  %local_2__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca %struct.ascii__String, align 8
+  store %struct.string__String %0, ptr %local_0, align 8
+  %srcval = load %struct.string__String, ptr %local_0, align 8
+  %ext_0 = extractvalue %struct.string__String %srcval, 0
+  store { ptr, i64, i64 } %ext_0, ptr %local_2__bytes, align 8
+  %call_arg_0 = load { ptr, i64, i64 }, ptr %local_2__bytes, align 8
+  %retval = call %struct.ascii__String @"0000000000000001_ascii_string_5ZneJ22oLb5aDc"({ ptr, i64, i64 } %call_arg_0)
+  store %struct.ascii__String %retval, ptr %local_3, align 8
+  %retval1 = load %struct.ascii__String, ptr %local_3, align 8
+  ret %struct.ascii__String %retval1
+}
+
+declare %struct.ascii__String @"0000000000000001_ascii_string_5ZneJ22oLb5aDc"({ ptr, i64, i64 })
+
+define %struct.option__Option_string__String_ @"0000000000000001_string_try_utf8_2NDjMousZSxnZr"({ ptr, i64, i64 } %0) {
+entry:
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca %struct.option__Option_string__String_, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i1, align 1
+  %local_4__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_5 = alloca %struct.string__String, align 8
+  %local_6 = alloca %struct.option__Option_string__String_, align 8
+  %local_7 = alloca %struct.option__Option_string__String_, align 8
+  %local_8 = alloca %struct.option__Option_string__String_, align 8
+  store { ptr, i64, i64 } %0, ptr %local_0, align 8
+  store ptr %local_0, ptr %local_2, align 8
+  %loaded_alloca = load ptr, ptr %local_2, align 8
+  %retval = call i1 @move_native_string_internal_check_utf8(ptr %loaded_alloca)
+  store i1 %retval, ptr %local_3, align 1
+  %cnd = load i1, ptr %local_3, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_0, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_4__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_4__bytes, align 8
+  %insert_0 = insertvalue %struct.string__String undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.string__String %insert_0, ptr %local_5, align 8
+  %call_arg_0 = load %struct.string__String, ptr %local_5, align 8
+  %retval1 = call %struct.option__Option_string__String_ @"0000000000000001_option_some_873wyos5WUFAHC"(%struct.string__String %call_arg_0)
+  store %struct.option__Option_string__String_ %retval1, ptr %local_6, align 8
+  %load_store_tmp2 = load %struct.option__Option_string__String_, ptr %local_6, align 8
+  store %struct.option__Option_string__String_ %load_store_tmp2, ptr %local_1, align 8
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %retval3 = call %struct.option__Option_string__String_ @"0000000000000001_option_none_DbiPSiGprCceap"()
+  store %struct.option__Option_string__String_ %retval3, ptr %local_7, align 8
+  %load_store_tmp4 = load %struct.option__Option_string__String_, ptr %local_7, align 8
+  store %struct.option__Option_string__String_ %load_store_tmp4, ptr %local_1, align 8
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_0, %bb_1
+  %retval5 = load %struct.option__Option_string__String_, ptr %local_1, align 8
+  ret %struct.option__Option_string__String_ %retval5
+}
+
+define private %struct.option__Option_string__String_ @"0000000000000001_option_some_873wyos5WUFAHC"(%struct.string__String %0) {
+entry:
+  %local_0 = alloca %struct.string__String, align 8
+  %local_1 = alloca %struct.string__String, align 8
+  %local_2__vec = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca %struct.option__Option_string__String_, align 8
+  store %struct.string__String %0, ptr %local_0, align 8
+  %call_arg_0 = load %struct.string__String, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000001_vector_singleton_GrW9zHe4R7RfoV"(%struct.string__String %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_2__vec, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_2__vec, align 8
+  %insert_0 = insertvalue %struct.option__Option_string__String_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.option__Option_string__String_ %insert_0, ptr %local_3, align 8
+  %retval1 = load %struct.option__Option_string__String_, ptr %local_3, align 8
+  ret %struct.option__Option_string__String_ %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000001_vector_singleton_GrW9zHe4R7RfoV"(%struct.string__String %0) {
+entry:
+  %local_0 = alloca %struct.string__String, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca %struct.string__String, align 8
+  %local_5 = alloca { ptr, i64, i64 }, align 8
+  store %struct.string__String %0, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_string__String)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_2, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_3, align 8
+  %loaded_alloca = load ptr, ptr %local_3, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_string__String, ptr %loaded_alloca, ptr %local_0)
+  %load_store_tmp1 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp1, ptr %local_5, align 8
+  %retval2 = load { ptr, i64, i64 }, ptr %local_5, align 8
+  ret { ptr, i64, i64 } %retval2
+}
+
+declare { ptr, i64, i64 } @move_native_vector_empty(ptr)
+
+define private %struct.option__Option_string__String_ @"0000000000000001_option_none_DbiPSiGprCceap"() {
+entry:
+  %local_0__vec = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca %struct.option__Option_string__String_, align 8
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_string__String)
+  store { ptr, i64, i64 } %retval, ptr %local_0__vec, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_0__vec, align 8
+  %insert_0 = insertvalue %struct.option__Option_string__String_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.option__Option_string__String_ %insert_0, ptr %local_1, align 8
+  %retval1 = load %struct.option__Option_string__String_, ptr %local_1, align 8
+  ret %struct.option__Option_string__String_ %retval1
+}
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)
+
+; Function Attrs: cold noreturn
+declare void @move_rt_abort(i64) #0
+
+attributes #0 = { cold noreturn }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x1__unit_test.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x1__unit_test.ll.expected
@@ -1,0 +1,30 @@
+; ModuleID = '0x1__unit_test'
+source_filename = "../../../../../../../crates/sui-framework/packages/move-stdlib/sources/unit_test.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+declare void @move_native_unit_test_poison()
+
+define void @"0000000000000001_unit_test_unit_test_poiso_4afD3MScT99fc9"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x1__vector.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x1__vector.ll.expected
@@ -1,0 +1,44 @@
+; ModuleID = '0x1__vector'
+source_filename = "../../../../../../../crates/sui-framework/packages/move-stdlib/sources/vector.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define void @"0000000000000001_vector_unit_test_poiso_HU6CqYnzBgTn4E"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+declare ptr @move_native_vector_borrow(ptr, ptr, i64)
+
+declare ptr @move_native_vector_borrow_mut(ptr, ptr, i64)
+
+declare void @move_native_vector_destroy_empty(ptr, ptr)
+
+declare { ptr, i64, i64 } @move_native_vector_empty(ptr)
+
+declare i64 @move_native_vector_length(ptr, ptr)
+
+declare void @move_native_vector_pop_back(ptr, ptr, ptr)
+
+declare void @move_native_vector_push_back(ptr, ptr, ptr)
+
+declare void @move_native_vector_swap(ptr, ptr, i64, i64)
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__address.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__address.ll.expected
@@ -1,0 +1,560 @@
+; ModuleID = '0x2__address'
+source_filename = "../../../../../../../crates/sui-framework/packages/sui-framework/sources/address.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+%struct.ascii__String = type { { ptr, i64, i64 } }
+%struct.string__String = type { { ptr, i64, i64 } }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+@__move_rttydesc_address = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_address_name, i64 7 }, i64 8, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_address_name = private unnamed_addr constant [7 x i8] c"address"
+@__move_rttydesc_u8 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u8_name, i64 2 }, i64 2, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u8_name = private unnamed_addr constant [2 x i8] c"u8"
+@vec_literal = internal constant [0 x i8] zeroinitializer
+@vdesc = internal constant { ptr, i64, i64 } { ptr @vec_literal, i64 0, i64 0 }
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define void @"0000000000000002_address_unit_test_poiso_8pEpVH3U2dJeNX"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+define i64 @"0000000000000002_address_length_85CkEAWyzLybDw"() {
+entry:
+  %local_0 = alloca i64, align 8
+  store i64 32, ptr %local_0, align 8
+  %retval = load i64, ptr %local_0, align 8
+  ret i64 %retval
+}
+
+define { ptr, i64, i64 } @"0000000000000002_address_to_bytes_3grjELHopGRxFE"([32 x i8] %0) {
+entry:
+  %local_0 = alloca [32 x i8], align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store [32 x i8] %0, ptr %local_0, align 1
+  store ptr %local_0, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_address, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+declare { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr, ptr)
+
+define [32 x i8] @"0000000000000002_address_from_ascii_byte_9VtoKvYynDBMrS"(ptr nonnull readonly %0) {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca i8, align 1
+  %local_5 = alloca ptr, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca ptr, align 8
+  %local_10 = alloca i64, align 8
+  %local_11 = alloca { ptr, i64, i64 }, align 8
+  %local_12 = alloca i64, align 8
+  %local_13 = alloca i64, align 8
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca i1, align 1
+  %local_16 = alloca ptr, align 8
+  %local_17 = alloca i64, align 8
+  %local_18 = alloca ptr, align 8
+  %local_19 = alloca i8, align 1
+  %local_20 = alloca i8, align 1
+  %local_21 = alloca ptr, align 8
+  %local_22 = alloca i64, align 8
+  %local_23 = alloca i64, align 8
+  %local_24 = alloca i64, align 8
+  %local_25 = alloca ptr, align 8
+  %local_26 = alloca i8, align 1
+  %local_27 = alloca i8, align 1
+  %local_28 = alloca ptr, align 8
+  %local_29 = alloca i8, align 1
+  %local_30 = alloca i8, align 1
+  %local_31 = alloca i8, align 1
+  %local_32 = alloca i8, align 1
+  %local_33 = alloca i8, align 1
+  %local_34 = alloca i64, align 8
+  %local_35 = alloca i64, align 8
+  %local_36 = alloca i64, align 8
+  %local_37 = alloca ptr, align 8
+  %local_38 = alloca { ptr, i64, i64 }, align 8
+  %local_39 = alloca [32 x i8], align 1
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_5, align 8
+  %loaded_alloca = load ptr, ptr %local_5, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_6, align 8
+  store i64 64, ptr %local_7, align 8
+  %eq_src_0 = load i64, ptr %local_6, align 8
+  %eq_src_1 = load i64, ptr %local_7, align 8
+  %eq_dst = icmp eq i64 %eq_src_0, %eq_src_1
+  store i1 %eq_dst, ptr %local_8, align 1
+  %cnd = load i1, ptr %local_8, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_9, align 8
+  store i64 0, ptr %local_10, align 8
+  %call_arg_0 = load i64, ptr %local_10, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %1, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_11, align 8
+  %load_store_tmp2 = load { ptr, i64, i64 }, ptr %local_11, align 8
+  store { ptr, i64, i64 } %load_store_tmp2, ptr %local_1, align 8
+  store i64 0, ptr %local_12, align 8
+  %load_store_tmp3 = load i64, ptr %local_12, align 8
+  store i64 %load_store_tmp3, ptr %local_3, align 8
+  br label %bb_6
+
+bb_6:                                             ; preds = %join_bb35, %bb_2
+  %load_store_tmp4 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp4, ptr %local_13, align 8
+  store i64 64, ptr %local_14, align 8
+  %lt_src_0 = load i64, ptr %local_13, align 8
+  %lt_src_1 = load i64, ptr %local_14, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_15, align 1
+  %cnd5 = load i1, ptr %local_15, align 1
+  br i1 %cnd5, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_6
+  br label %bb_5
+
+bb_5:                                             ; preds = %bb_4
+  %load_store_tmp6 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp6, ptr %local_16, align 8
+  %load_store_tmp7 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp7, ptr %local_17, align 8
+  %loaded_alloca8 = load ptr, ptr %local_16, align 8
+  %loaded_alloca9 = load i64, ptr %local_17, align 8
+  %retval10 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_u8, ptr %loaded_alloca8, i64 %loaded_alloca9)
+  store ptr %retval10, ptr %local_18, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_18, align 8
+  %load_deref_store_tmp2 = load i8, ptr %load_deref_store_tmp1, align 1
+  store i8 %load_deref_store_tmp2, ptr %local_19, align 1
+  %call_arg_011 = load i8, ptr %local_19, align 1
+  %retval12 = call i8 @"0000000000000002_address_hex_char_value_AeTq47yEvQVk1F"(i8 %call_arg_011)
+  store i8 %retval12, ptr %local_20, align 1
+  %load_store_tmp13 = load i8, ptr %local_20, align 1
+  store i8 %load_store_tmp13, ptr %local_2, align 1
+  %load_store_tmp14 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp14, ptr %local_21, align 8
+  %load_store_tmp15 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp15, ptr %local_22, align 8
+  store i64 1, ptr %local_23, align 8
+  %add_src_0 = load i64, ptr %local_22, align 8
+  %add_src_1 = load i64, ptr %local_23, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_5
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_5
+  store i64 %add_dst, ptr %local_24, align 8
+  %loaded_alloca16 = load ptr, ptr %local_21, align 8
+  %loaded_alloca17 = load i64, ptr %local_24, align 8
+  %retval18 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_u8, ptr %loaded_alloca16, i64 %loaded_alloca17)
+  store ptr %retval18, ptr %local_25, align 8
+  %load_deref_store_tmp119 = load ptr, ptr %local_25, align 8
+  %load_deref_store_tmp220 = load i8, ptr %load_deref_store_tmp119, align 1
+  store i8 %load_deref_store_tmp220, ptr %local_26, align 1
+  %call_arg_021 = load i8, ptr %local_26, align 1
+  %retval22 = call i8 @"0000000000000002_address_hex_char_value_AeTq47yEvQVk1F"(i8 %call_arg_021)
+  store i8 %retval22, ptr %local_27, align 1
+  %load_store_tmp23 = load i8, ptr %local_27, align 1
+  store i8 %load_store_tmp23, ptr %local_4, align 1
+  store ptr %local_1, ptr %local_28, align 8
+  %load_store_tmp24 = load i8, ptr %local_2, align 1
+  store i8 %load_store_tmp24, ptr %local_29, align 1
+  store i8 4, ptr %local_30, align 1
+  %shl_src_0 = load i8, ptr %local_29, align 1
+  %shl_src_1 = load i8, ptr %local_30, align 1
+  %rangecond = icmp uge i8 %shl_src_1, 8
+  br i1 %rangecond, label %then_bb25, label %join_bb26
+
+then_bb25:                                        ; preds = %join_bb
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb26:                                        ; preds = %join_bb
+  %shl_dst = shl i8 %shl_src_0, %shl_src_1
+  store i8 %shl_dst, ptr %local_31, align 1
+  %load_store_tmp27 = load i8, ptr %local_4, align 1
+  store i8 %load_store_tmp27, ptr %local_32, align 1
+  %or_src_0 = load i8, ptr %local_31, align 1
+  %or_src_1 = load i8, ptr %local_32, align 1
+  %or_dst = or i8 %or_src_0, %or_src_1
+  store i8 %or_dst, ptr %local_33, align 1
+  %loaded_alloca28 = load ptr, ptr %local_28, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca28, ptr %local_33)
+  %load_store_tmp29 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp29, ptr %local_34, align 8
+  store i64 2, ptr %local_35, align 8
+  %add_src_030 = load i64, ptr %local_34, align 8
+  %add_src_131 = load i64, ptr %local_35, align 8
+  %add_dst32 = add i64 %add_src_030, %add_src_131
+  %ovfcond33 = icmp ult i64 %add_dst32, %add_src_030
+  br i1 %ovfcond33, label %then_bb34, label %join_bb35
+
+then_bb34:                                        ; preds = %join_bb26
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb35:                                        ; preds = %join_bb26
+  store i64 %add_dst32, ptr %local_36, align 8
+  %load_store_tmp36 = load i64, ptr %local_36, align 8
+  store i64 %load_store_tmp36, ptr %local_3, align 8
+  br label %bb_6
+
+bb_3:                                             ; preds = %bb_6
+  %load_store_tmp37 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp37, ptr %local_37, align 8
+  %load_store_tmp38 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp38, ptr %local_38, align 8
+  %retval39 = call [32 x i8] @move_native_address_from_bytes(ptr %local_38)
+  store [32 x i8] %retval39, ptr %local_39, align 1
+  %retval40 = load [32 x i8], ptr %local_39, align 1
+  ret [32 x i8] %retval40
+}
+
+declare i64 @move_native_vector_length(ptr, ptr)
+
+declare ptr @move_native_vector_borrow(ptr, ptr, i64)
+
+define private i8 @"0000000000000002_address_hex_char_value_AeTq47yEvQVk1F"(i8 %0) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i1, align 1
+  %local_2 = alloca i1, align 1
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i8, align 1
+  %local_5 = alloca i8, align 1
+  %local_6 = alloca i8, align 1
+  %local_7 = alloca i8, align 1
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca i8, align 1
+  %local_10 = alloca i8, align 1
+  %local_11 = alloca i1, align 1
+  %local_12 = alloca i1, align 1
+  %local_13 = alloca i1, align 1
+  %local_14 = alloca i8, align 1
+  %local_15 = alloca i8, align 1
+  %local_16 = alloca i8, align 1
+  %local_17 = alloca i8, align 1
+  %local_18 = alloca i8, align 1
+  %local_19 = alloca i1, align 1
+  %local_20 = alloca i8, align 1
+  %local_21 = alloca i8, align 1
+  %local_22 = alloca i1, align 1
+  %local_23 = alloca i1, align 1
+  %local_24 = alloca i1, align 1
+  %local_25 = alloca i8, align 1
+  %local_26 = alloca i8, align 1
+  %local_27 = alloca i8, align 1
+  %local_28 = alloca i8, align 1
+  %local_29 = alloca i8, align 1
+  %local_30 = alloca i1, align 1
+  %local_31 = alloca i8, align 1
+  %local_32 = alloca i8, align 1
+  %local_33 = alloca i1, align 1
+  %local_34 = alloca i1, align 1
+  %local_35 = alloca i1, align 1
+  %local_36 = alloca i64, align 8
+  %local_37 = alloca i8, align 1
+  %local_38 = alloca i8, align 1
+  %local_39 = alloca i8, align 1
+  %local_40 = alloca i8, align 1
+  %local_41 = alloca i8, align 1
+  store i8 %0, ptr %local_0, align 1
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_6, align 1
+  store i8 48, ptr %local_7, align 1
+  %ge_src_0 = load i8, ptr %local_6, align 1
+  %ge_src_1 = load i8, ptr %local_7, align 1
+  %ge_dst = icmp uge i8 %ge_src_0, %ge_src_1
+  store i1 %ge_dst, ptr %local_8, align 1
+  %cnd = load i1, ptr %local_8, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  %load_store_tmp1 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp1, ptr %local_9, align 1
+  store i8 57, ptr %local_10, align 1
+  %le_src_0 = load i8, ptr %local_9, align 1
+  %le_src_1 = load i8, ptr %local_10, align 1
+  %le_dst = icmp ule i8 %le_src_0, %le_src_1
+  store i1 %le_dst, ptr %local_11, align 1
+  %load_store_tmp2 = load i1, ptr %local_11, align 1
+  store i1 %load_store_tmp2, ptr %local_1, align 1
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i1 false, ptr %local_12, align 1
+  %load_store_tmp3 = load i1, ptr %local_12, align 1
+  store i1 %load_store_tmp3, ptr %local_1, align 1
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_0, %bb_1
+  %load_store_tmp4 = load i1, ptr %local_1, align 1
+  store i1 %load_store_tmp4, ptr %local_13, align 1
+  %cnd5 = load i1, ptr %local_13, align 1
+  br i1 %cnd5, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  %load_store_tmp6 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp6, ptr %local_14, align 1
+  store i8 48, ptr %local_15, align 1
+  %sub_src_0 = load i8, ptr %local_14, align 1
+  %sub_src_1 = load i8, ptr %local_15, align 1
+  %sub_dst = sub i8 %sub_src_0, %sub_src_1
+  %ovfcond = icmp ugt i8 %sub_dst, %sub_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_4
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_4
+  store i8 %sub_dst, ptr %local_16, align 1
+  %load_store_tmp7 = load i8, ptr %local_16, align 1
+  store i8 %load_store_tmp7, ptr %local_5, align 1
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  %load_store_tmp8 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp8, ptr %local_17, align 1
+  store i8 65, ptr %local_18, align 1
+  %ge_src_09 = load i8, ptr %local_17, align 1
+  %ge_src_110 = load i8, ptr %local_18, align 1
+  %ge_dst11 = icmp uge i8 %ge_src_09, %ge_src_110
+  store i1 %ge_dst11, ptr %local_19, align 1
+  %cnd12 = load i1, ptr %local_19, align 1
+  br i1 %cnd12, label %bb_7, label %bb_6
+
+bb_7:                                             ; preds = %bb_3
+  %load_store_tmp13 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp13, ptr %local_20, align 1
+  store i8 70, ptr %local_21, align 1
+  %le_src_014 = load i8, ptr %local_20, align 1
+  %le_src_115 = load i8, ptr %local_21, align 1
+  %le_dst16 = icmp ule i8 %le_src_014, %le_src_115
+  store i1 %le_dst16, ptr %local_22, align 1
+  %load_store_tmp17 = load i1, ptr %local_22, align 1
+  store i1 %load_store_tmp17, ptr %local_2, align 1
+  br label %bb_8
+
+bb_6:                                             ; preds = %bb_3
+  store i1 false, ptr %local_23, align 1
+  %load_store_tmp18 = load i1, ptr %local_23, align 1
+  store i1 %load_store_tmp18, ptr %local_2, align 1
+  br label %bb_8
+
+bb_8:                                             ; preds = %bb_6, %bb_7
+  %load_store_tmp19 = load i1, ptr %local_2, align 1
+  store i1 %load_store_tmp19, ptr %local_24, align 1
+  %cnd20 = load i1, ptr %local_24, align 1
+  br i1 %cnd20, label %bb_10, label %bb_9
+
+bb_10:                                            ; preds = %bb_8
+  %load_store_tmp21 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp21, ptr %local_25, align 1
+  store i8 55, ptr %local_26, align 1
+  %sub_src_022 = load i8, ptr %local_25, align 1
+  %sub_src_123 = load i8, ptr %local_26, align 1
+  %sub_dst24 = sub i8 %sub_src_022, %sub_src_123
+  %ovfcond25 = icmp ugt i8 %sub_dst24, %sub_src_022
+  br i1 %ovfcond25, label %then_bb26, label %join_bb27
+
+then_bb26:                                        ; preds = %bb_10
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb27:                                        ; preds = %bb_10
+  store i8 %sub_dst24, ptr %local_27, align 1
+  %load_store_tmp28 = load i8, ptr %local_27, align 1
+  store i8 %load_store_tmp28, ptr %local_4, align 1
+  br label %bb_11
+
+bb_9:                                             ; preds = %bb_8
+  %load_store_tmp29 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp29, ptr %local_28, align 1
+  store i8 97, ptr %local_29, align 1
+  %ge_src_030 = load i8, ptr %local_28, align 1
+  %ge_src_131 = load i8, ptr %local_29, align 1
+  %ge_dst32 = icmp uge i8 %ge_src_030, %ge_src_131
+  store i1 %ge_dst32, ptr %local_30, align 1
+  %cnd33 = load i1, ptr %local_30, align 1
+  br i1 %cnd33, label %bb_13, label %bb_12
+
+bb_13:                                            ; preds = %bb_9
+  %load_store_tmp34 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp34, ptr %local_31, align 1
+  store i8 102, ptr %local_32, align 1
+  %le_src_035 = load i8, ptr %local_31, align 1
+  %le_src_136 = load i8, ptr %local_32, align 1
+  %le_dst37 = icmp ule i8 %le_src_035, %le_src_136
+  store i1 %le_dst37, ptr %local_33, align 1
+  %load_store_tmp38 = load i1, ptr %local_33, align 1
+  store i1 %load_store_tmp38, ptr %local_3, align 1
+  br label %bb_14
+
+bb_12:                                            ; preds = %bb_9
+  store i1 false, ptr %local_34, align 1
+  %load_store_tmp39 = load i1, ptr %local_34, align 1
+  store i1 %load_store_tmp39, ptr %local_3, align 1
+  br label %bb_14
+
+bb_14:                                            ; preds = %bb_12, %bb_13
+  %load_store_tmp40 = load i1, ptr %local_3, align 1
+  store i1 %load_store_tmp40, ptr %local_35, align 1
+  %cnd41 = load i1, ptr %local_35, align 1
+  br i1 %cnd41, label %bb_16, label %bb_15
+
+bb_16:                                            ; preds = %bb_14
+  br label %bb_17
+
+bb_15:                                            ; preds = %bb_14
+  store i64 0, ptr %local_36, align 8
+  %call_arg_0 = load i64, ptr %local_36, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_17:                                            ; preds = %bb_16
+  %load_store_tmp42 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp42, ptr %local_37, align 1
+  store i8 87, ptr %local_38, align 1
+  %sub_src_043 = load i8, ptr %local_37, align 1
+  %sub_src_144 = load i8, ptr %local_38, align 1
+  %sub_dst45 = sub i8 %sub_src_043, %sub_src_144
+  %ovfcond46 = icmp ugt i8 %sub_dst45, %sub_src_043
+  br i1 %ovfcond46, label %then_bb47, label %join_bb48
+
+then_bb47:                                        ; preds = %bb_17
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb48:                                        ; preds = %bb_17
+  store i8 %sub_dst45, ptr %local_39, align 1
+  %load_store_tmp49 = load i8, ptr %local_39, align 1
+  store i8 %load_store_tmp49, ptr %local_4, align 1
+  br label %bb_11
+
+bb_11:                                            ; preds = %join_bb48, %join_bb27
+  %load_store_tmp50 = load i8, ptr %local_4, align 1
+  store i8 %load_store_tmp50, ptr %local_40, align 1
+  %load_store_tmp51 = load i8, ptr %local_40, align 1
+  store i8 %load_store_tmp51, ptr %local_5, align 1
+  br label %bb_5
+
+bb_5:                                             ; preds = %bb_11, %join_bb
+  %load_store_tmp52 = load i8, ptr %local_5, align 1
+  store i8 %load_store_tmp52, ptr %local_41, align 1
+  %retval = load i8, ptr %local_41, align 1
+  ret i8 %retval
+}
+
+declare void @move_native_vector_push_back(ptr, ptr, ptr)
+
+declare [32 x i8] @move_native_address_from_bytes(ptr)
+
+declare [32 x i8] @move_native_address_from_u256(i256)
+
+define i256 @"0000000000000002_address_max_3uU9PexnFfro2a"() {
+entry:
+  %local_0 = alloca i256, align 8
+  store i256 -1, ptr %local_0, align 8
+  %retval = load i256, ptr %local_0, align 8
+  ret i256 %retval
+}
+
+define %struct.ascii__String @"0000000000000002_address_to_ascii_string_91iAZAjJJNcNQe"([32 x i8] %0) {
+entry:
+  %local_0 = alloca [32 x i8], align 1
+  %local_1 = alloca [32 x i8], align 1
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca { ptr, i64, i64 }, align 8
+  %local_4 = alloca %struct.ascii__String, align 8
+  store [32 x i8] %0, ptr %local_0, align 1
+  %call_arg_0 = load [32 x i8], ptr %local_0, align 1
+  %retval = call { ptr, i64, i64 } @"0000000000000002_address_to_bytes_3grjELHopGRxFE"([32 x i8] %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %call_arg_01 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  %retval2 = call { ptr, i64, i64 } @"0000000000000002_hex_encode_2jkRtUUZsDAoo8"({ ptr, i64, i64 } %call_arg_01)
+  store { ptr, i64, i64 } %retval2, ptr %local_3, align 8
+  %call_arg_03 = load { ptr, i64, i64 }, ptr %local_3, align 8
+  %retval4 = call %struct.ascii__String @"0000000000000001_ascii_string_5ZneJ22oLb5aDc"({ ptr, i64, i64 } %call_arg_03)
+  store %struct.ascii__String %retval4, ptr %local_4, align 8
+  %retval5 = load %struct.ascii__String, ptr %local_4, align 8
+  ret %struct.ascii__String %retval5
+}
+
+declare { ptr, i64, i64 } @"0000000000000002_hex_encode_2jkRtUUZsDAoo8"({ ptr, i64, i64 })
+
+declare %struct.ascii__String @"0000000000000001_ascii_string_5ZneJ22oLb5aDc"({ ptr, i64, i64 })
+
+define %struct.string__String @"0000000000000002_address_to_string_7sDhBZ6D7CR3fZ"([32 x i8] %0) {
+entry:
+  %local_0 = alloca [32 x i8], align 1
+  %local_1 = alloca [32 x i8], align 1
+  %local_2 = alloca %struct.ascii__String, align 8
+  %local_3 = alloca %struct.string__String, align 8
+  store [32 x i8] %0, ptr %local_0, align 1
+  %call_arg_0 = load [32 x i8], ptr %local_0, align 1
+  %retval = call %struct.ascii__String @"0000000000000002_address_to_ascii_string_91iAZAjJJNcNQe"([32 x i8] %call_arg_0)
+  store %struct.ascii__String %retval, ptr %local_2, align 8
+  %call_arg_01 = load %struct.ascii__String, ptr %local_2, align 8
+  %retval2 = call %struct.string__String @"0000000000000001_string_from_ascii_231x8gDp4D9p4F"(%struct.ascii__String %call_arg_01)
+  store %struct.string__String %retval2, ptr %local_3, align 8
+  %retval3 = load %struct.string__String, ptr %local_3, align 8
+  ret %struct.string__String %retval3
+}
+
+declare %struct.string__String @"0000000000000001_string_from_ascii_231x8gDp4D9p4F"(%struct.ascii__String)
+
+declare i256 @move_native_address_to_u256([32 x i8])
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)
+
+; Function Attrs: cold noreturn
+declare void @move_rt_abort(i64) #0
+
+declare { ptr, i64, i64 } @move_rt_vec_empty(ptr nonnull readonly dereferenceable(32))
+
+declare void @move_rt_vec_copy(ptr nonnull readonly dereferenceable(32), ptr nonnull dereferenceable(24), ptr nonnull readonly dereferenceable(24))
+
+attributes #0 = { cold noreturn }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__bcs.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__bcs.ll.expected
@@ -1,0 +1,4026 @@
+; ModuleID = '0x2__bcs'
+source_filename = "../../../../../../../crates/sui-framework/packages/sui-framework/sources/bcs.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+%struct.bcs__BCS = type { { ptr, i64, i64 } }
+%struct.option__Option_address_ = type { { ptr, i64, i64 } }
+%struct.option__Option_bool_ = type { { ptr, i64, i64 } }
+%struct.option__Option_u128_ = type { { ptr, i64, i64 } }
+%struct.option__Option_u64_ = type { { ptr, i64, i64 } }
+%struct.option__Option_u8_ = type { { ptr, i64, i64 } }
+%struct.bcs__Info = type { i1, i8, i64, i128, { ptr, i64, i64 }, [32 x i8] }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+@__move_rttydesc_u8 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u8_name, i64 2 }, i64 2, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u8_name = private unnamed_addr constant [2 x i8] c"u8"
+@__move_rttydesc_address = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_address_name, i64 7 }, i64 8, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_address_name = private unnamed_addr constant [7 x i8] c"address"
+@__move_rttydesc_bool = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_bool_name, i64 4 }, i64 1, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_bool_name = private unnamed_addr constant [4 x i8] c"bool"
+@__move_rttydesc_u128 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u128_name, i64 4 }, i64 6, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u128_name = private unnamed_addr constant [4 x i8] c"u128"
+@__move_rttydesc_u64 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u64_name, i64 3 }, i64 5, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u64_name = private unnamed_addr constant [3 x i8] c"u64"
+@vec_literal = internal constant [0 x [32 x i8]] zeroinitializer
+@vdesc = internal constant { ptr, i64, i64 } { ptr @vec_literal, i64 0, i64 0 }
+@vec_literal.1 = internal constant [0 x i1] zeroinitializer
+@vdesc.2 = internal constant { ptr, i64, i64 } { ptr @vec_literal.1, i64 0, i64 0 }
+@vec_literal.3 = internal constant [0 x i128] zeroinitializer
+@vdesc.4 = internal constant { ptr, i64, i64 } { ptr @vec_literal.3, i64 0, i64 0 }
+@vec_literal.5 = internal constant [0 x i64] zeroinitializer
+@vdesc.6 = internal constant { ptr, i64, i64 } { ptr @vec_literal.5, i64 0, i64 0 }
+@vec_literal.7 = internal constant [0 x i8] zeroinitializer
+@vdesc.8 = internal constant { ptr, i64, i64 } { ptr @vec_literal.7, i64 0, i64 0 }
+@vec_literal.9 = internal constant [0 x i8] zeroinitializer
+@vdesc.10 = internal constant { ptr, i64, i64 } { ptr @vec_literal.9, i64 0, i64 0 }
+@__move_rttydesc_vector_u8_ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_u8__name, i64 10 }, i64 10, ptr @__move_rttydesc_vector_u8__info }
+@__move_rttydesc_vector_u8__name = private unnamed_addr constant [10 x i8] c"vector<u8>"
+@__move_rttydesc_vector_u8__info = private unnamed_addr constant { ptr } { ptr @__move_rttydesc_u8 }
+@acct.addr = internal constant [32 x i8] c"\EE\FF\C0\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+@vec_literal.11 = internal constant [15 x i64] zeroinitializer
+@vdesc.12 = internal constant { ptr, i64, i64 } { ptr @vec_literal.11, i64 15, i64 15 }
+@vec_literal.13 = internal constant [360 x i64] zeroinitializer
+@vdesc.14 = internal constant { ptr, i64, i64 } { ptr @vec_literal.13, i64 360, i64 360 }
+@vec_literal.15 = internal constant [4 x i1] [i1 true, i1 false, i1 true, i1 false]
+@vdesc.16 = internal constant { ptr, i64, i64 } { ptr @vec_literal.15, i64 4, i64 4 }
+@acct.addr.17 = internal constant [32 x i8] c"\AA\AA\AA\AA\AA\0A\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+@vec_literal.18 = internal constant [5 x i8] c"\01\02\03\04\05"
+@vdesc.19 = internal constant { ptr, i64, i64 } { ptr @vec_literal.18, i64 5, i64 5 }
+@vec_literal.20 = internal constant [5 x i8] c"\01\02\03\04\05"
+@vdesc.21 = internal constant { ptr, i64, i64 } { ptr @vec_literal.20, i64 5, i64 5 }
+@vec_literal.22 = internal constant [5 x i64] [i64 1, i64 2, i64 3, i64 4, i64 5]
+@vdesc.23 = internal constant { ptr, i64, i64 } { ptr @vec_literal.22, i64 5, i64 5 }
+@vec_literal.24 = internal constant [5 x i128] [i128 1, i128 2, i128 3, i128 4, i128 5]
+@vdesc.25 = internal constant { ptr, i64, i64 } { ptr @vec_literal.24, i64 5, i64 5 }
+@vec_literal.26 = internal constant [4 x i1] [i1 true, i1 false, i1 true, i1 false]
+@vdesc.27 = internal constant { ptr, i64, i64 } { ptr @vec_literal.26, i64 4, i64 4 }
+@vec_literal.28 = internal constant [4 x [32 x i8]] [[32 x i8] zeroinitializer, [32 x i8] c"\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [32 x i8] c"\02\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [32 x i8] c"\03\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"]
+@vdesc.29 = internal constant { ptr, i64, i64 } { ptr @vec_literal.28, i64 4, i64 4 }
+@__move_rttydesc_vector_u64_ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_u64__name, i64 11 }, i64 10, ptr @__move_rttydesc_vector_u64__info }
+@__move_rttydesc_vector_u64__name = private unnamed_addr constant [11 x i8] c"vector<u64>"
+@__move_rttydesc_vector_u64__info = private unnamed_addr constant { ptr } { ptr @__move_rttydesc_u64 }
+@__move_rttydesc_bcs__Info = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_bcs__Info_name, i64 75 }, i64 11, ptr @__move_rttydesc_bcs__Info_info }
+@__move_rttydesc_bcs__Info_name = private unnamed_addr constant [75 x i8] c"0000000000000000000000000000000000000000000000000000000000000002::bcs::Info"
+@0 = private unnamed_addr constant [1 x i8] c"a"
+@1 = private unnamed_addr constant [1 x i8] c"b"
+@2 = private unnamed_addr constant [1 x i8] c"c"
+@3 = private unnamed_addr constant [1 x i8] c"d"
+@__move_rttydesc_vector_bool__name = private unnamed_addr constant [12 x i8] c"vector<bool>"
+@__move_rttydesc_vector_bool__info = private unnamed_addr constant { ptr } { ptr @__move_rttydesc_bool }
+@4 = private unnamed_addr constant [1 x i8] c"k"
+@5 = private unnamed_addr constant [1 x i8] c"s"
+@s_fld_array = private unnamed_addr constant [6 x { %__move_rt_type, i64, { ptr, i64 } }] [{ %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_bool_name, i64 4 }, i64 1, ptr @__move_rttydesc_NOTHING_info }, i64 0, { ptr, i64 } { ptr @0, i64 1 } }, { %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u8_name, i64 2 }, i64 2, ptr @__move_rttydesc_NOTHING_info }, i64 1, { ptr, i64 } { ptr @1, i64 1 } }, { %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u64_name, i64 3 }, i64 5, ptr @__move_rttydesc_NOTHING_info }, i64 8, { ptr, i64 } { ptr @2, i64 1 } }, { %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u128_name, i64 4 }, i64 6, ptr @__move_rttydesc_NOTHING_info }, i64 16, { ptr, i64 } { ptr @3, i64 1 } }, { %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_bool__name, i64 12 }, i64 10, ptr @__move_rttydesc_vector_bool__info }, i64 32, { ptr, i64 } { ptr @4, i64 1 } }, { %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_address_name, i64 7 }, i64 8, ptr @__move_rttydesc_NOTHING_info }, i64 56, { ptr, i64 } { ptr @5, i64 1 } }]
+@__move_rttydesc_bcs__Info_info = private unnamed_addr constant { ptr, i64, i64, i64 } { ptr @s_fld_array, i64 6, i64 88, i64 8 }
+@__move_rttydesc_vector_vector_u8__ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_vector_u8___name, i64 18 }, i64 10, ptr @__move_rttydesc_vector_vector_u8___info }
+@__move_rttydesc_vector_vector_u8___name = private unnamed_addr constant [18 x i8] c"vector<vector<u8>>"
+@__move_rttydesc_vector_vector_u8___info = private unnamed_addr constant { ptr } { ptr @__move_rttydesc_vector_u8_ }
+@__move_rttydesc_vector_u128_ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_u128__name, i64 12 }, i64 10, ptr @__move_rttydesc_vector_u128__info }
+@__move_rttydesc_vector_u128__name = private unnamed_addr constant [12 x i8] c"vector<u128>"
+@__move_rttydesc_vector_u128__info = private unnamed_addr constant { ptr } { ptr @__move_rttydesc_u128 }
+@__move_rttydesc_vector_bool_ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_bool__name, i64 12 }, i64 10, ptr @__move_rttydesc_vector_bool__info }
+@__move_rttydesc_vector_address_ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_address__name, i64 15 }, i64 10, ptr @__move_rttydesc_vector_address__info }
+@__move_rttydesc_vector_address__name = private unnamed_addr constant [15 x i8] c"vector<address>"
+@__move_rttydesc_vector_address__info = private unnamed_addr constant { ptr } { ptr @__move_rttydesc_address }
+@__move_rttydesc_option__Option_bool_ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_option__Option_bool__name, i64 86 }, i64 11, ptr @__move_rttydesc_option__Option_bool__info }
+@__move_rttydesc_option__Option_bool__name = private unnamed_addr constant [86 x i8] c"0000000000000000000000000000000000000000000000000000000000000001::option::Option<bool>"
+@6 = private unnamed_addr constant [3 x i8] c"vec"
+@s_fld_array.30 = private unnamed_addr constant [1 x { %__move_rt_type, i64, { ptr, i64 } }] [{ %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_bool__name, i64 12 }, i64 10, ptr @__move_rttydesc_vector_bool__info }, i64 0, { ptr, i64 } { ptr @6, i64 3 } }]
+@__move_rttydesc_option__Option_bool__info = private unnamed_addr constant { ptr, i64, i64, i64 } { ptr @s_fld_array.30, i64 1, i64 24, i64 8 }
+@__move_rttydesc_option__Option_u8_ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_option__Option_u8__name, i64 84 }, i64 11, ptr @__move_rttydesc_option__Option_u8__info }
+@__move_rttydesc_option__Option_u8__name = private unnamed_addr constant [84 x i8] c"0000000000000000000000000000000000000000000000000000000000000001::option::Option<u8>"
+@7 = private unnamed_addr constant [3 x i8] c"vec"
+@s_fld_array.31 = private unnamed_addr constant [1 x { %__move_rt_type, i64, { ptr, i64 } }] [{ %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_u8__name, i64 10 }, i64 10, ptr @__move_rttydesc_vector_u8__info }, i64 0, { ptr, i64 } { ptr @7, i64 3 } }]
+@__move_rttydesc_option__Option_u8__info = private unnamed_addr constant { ptr, i64, i64, i64 } { ptr @s_fld_array.31, i64 1, i64 24, i64 8 }
+@__move_rttydesc_option__Option_u64_ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_option__Option_u64__name, i64 85 }, i64 11, ptr @__move_rttydesc_option__Option_u64__info }
+@__move_rttydesc_option__Option_u64__name = private unnamed_addr constant [85 x i8] c"0000000000000000000000000000000000000000000000000000000000000001::option::Option<u64>"
+@8 = private unnamed_addr constant [3 x i8] c"vec"
+@s_fld_array.32 = private unnamed_addr constant [1 x { %__move_rt_type, i64, { ptr, i64 } }] [{ %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_u64__name, i64 11 }, i64 10, ptr @__move_rttydesc_vector_u64__info }, i64 0, { ptr, i64 } { ptr @8, i64 3 } }]
+@__move_rttydesc_option__Option_u64__info = private unnamed_addr constant { ptr, i64, i64, i64 } { ptr @s_fld_array.32, i64 1, i64 24, i64 8 }
+@__move_rttydesc_option__Option_u128_ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_option__Option_u128__name, i64 86 }, i64 11, ptr @__move_rttydesc_option__Option_u128__info }
+@__move_rttydesc_option__Option_u128__name = private unnamed_addr constant [86 x i8] c"0000000000000000000000000000000000000000000000000000000000000001::option::Option<u128>"
+@9 = private unnamed_addr constant [3 x i8] c"vec"
+@s_fld_array.33 = private unnamed_addr constant [1 x { %__move_rt_type, i64, { ptr, i64 } }] [{ %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_u128__name, i64 12 }, i64 10, ptr @__move_rttydesc_vector_u128__info }, i64 0, { ptr, i64 } { ptr @9, i64 3 } }]
+@__move_rttydesc_option__Option_u128__info = private unnamed_addr constant { ptr, i64, i64, i64 } { ptr @s_fld_array.33, i64 1, i64 24, i64 8 }
+@acct.addr.34 = internal constant [32 x i8] c"\EE\FF\C0\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+@__move_rttydesc_option__Option_address_ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_option__Option_address__name, i64 89 }, i64 11, ptr @__move_rttydesc_option__Option_address__info }
+@__move_rttydesc_option__Option_address__name = private unnamed_addr constant [89 x i8] c"0000000000000000000000000000000000000000000000000000000000000001::option::Option<address>"
+@10 = private unnamed_addr constant [3 x i8] c"vec"
+@s_fld_array.35 = private unnamed_addr constant [1 x { %__move_rt_type, i64, { ptr, i64 } }] [{ %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_address__name, i64 15 }, i64 10, ptr @__move_rttydesc_vector_address__info }, i64 0, { ptr, i64 } { ptr @10, i64 3 } }]
+@__move_rttydesc_option__Option_address__info = private unnamed_addr constant { ptr, i64, i64, i64 } { ptr @s_fld_array.35, i64 1, i64 24, i64 8 }
+@vec_literal.36 = internal constant [5 x i64] [i64 255, i64 255, i64 255, i64 255, i64 255]
+@vdesc.37 = internal constant { ptr, i64, i64 } { ptr @vec_literal.36, i64 5, i64 5 }
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define void @"0000000000000002_bcs_unit_test_poiso_jNd5pQz4ATxE8G"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+define { ptr, i64, i64 } @"0000000000000002_bcs_into_remainder__ywtPgSuW7MMmdy"(%struct.bcs__BCS %0) {
+entry:
+  %local_0 = alloca %struct.bcs__BCS, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca %struct.bcs__BCS, align 8
+  %local_3__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca { ptr, i64, i64 }, align 8
+  store %struct.bcs__BCS %0, ptr %local_0, align 8
+  %srcval = load %struct.bcs__BCS, ptr %local_0, align 8
+  %ext_0 = extractvalue %struct.bcs__BCS %srcval, 0
+  store { ptr, i64, i64 } %ext_0, ptr %local_3__bytes, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_3__bytes, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_4, align 8
+  %call_arg_0 = load ptr, ptr %local_4, align 8
+  call void @"0000000000000001_vector_reverse_DYV9motnmmM5cs"(ptr %call_arg_0)
+  %load_store_tmp1 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp1, ptr %local_5, align 8
+  %retval = load { ptr, i64, i64 }, ptr %local_5, align 8
+  ret { ptr, i64, i64 } %retval
+}
+
+define private void @"0000000000000001_vector_reverse_DYV9motnmmM5cs"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca ptr, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i1, align 1
+  %local_10 = alloca ptr, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca i64, align 8
+  %local_13 = alloca i64, align 8
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca i1, align 1
+  %local_18 = alloca ptr, align 8
+  %local_19 = alloca i64, align 8
+  %local_20 = alloca i64, align 8
+  %local_21 = alloca i64, align 8
+  %local_22 = alloca i64, align 8
+  %local_23 = alloca i64, align 8
+  %local_24 = alloca i64, align 8
+  %local_25 = alloca i64, align 8
+  %local_26 = alloca i64, align 8
+  %local_27 = alloca ptr, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_4, align 8
+  %load_store_tmp1 = load ptr, ptr %local_4, align 8
+  store ptr %load_store_tmp1, ptr %local_5, align 8
+  %loaded_alloca = load ptr, ptr %local_5, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_6, align 8
+  %load_store_tmp2 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp2, ptr %local_3, align 8
+  %load_store_tmp3 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp3, ptr %local_7, align 8
+  store i64 0, ptr %local_8, align 8
+  %eq_src_0 = load i64, ptr %local_7, align 8
+  %eq_src_1 = load i64, ptr %local_8, align 8
+  %eq_dst = icmp eq i64 %eq_src_0, %eq_src_1
+  store i1 %eq_dst, ptr %local_9, align 1
+  %cnd = load i1, ptr %local_9, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  %load_store_tmp4 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp4, ptr %local_10, align 8
+  ret void
+
+bb_0:                                             ; preds = %entry
+  store i64 0, ptr %local_11, align 8
+  %load_store_tmp5 = load i64, ptr %local_11, align 8
+  store i64 %load_store_tmp5, ptr %local_2, align 8
+  %load_store_tmp6 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp6, ptr %local_12, align 8
+  store i64 1, ptr %local_13, align 8
+  %sub_src_0 = load i64, ptr %local_12, align 8
+  %sub_src_1 = load i64, ptr %local_13, align 8
+  %sub_dst = sub i64 %sub_src_0, %sub_src_1
+  %ovfcond = icmp ugt i64 %sub_dst, %sub_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_0
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_0
+  store i64 %sub_dst, ptr %local_14, align 8
+  %load_store_tmp7 = load i64, ptr %local_14, align 8
+  store i64 %load_store_tmp7, ptr %local_1, align 8
+  br label %bb_5
+
+bb_5:                                             ; preds = %join_bb28, %join_bb
+  %load_store_tmp8 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp8, ptr %local_15, align 8
+  %load_store_tmp9 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp9, ptr %local_16, align 8
+  %lt_src_0 = load i64, ptr %local_15, align 8
+  %lt_src_1 = load i64, ptr %local_16, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_17, align 1
+  %cnd10 = load i1, ptr %local_17, align 1
+  br i1 %cnd10, label %bb_3, label %bb_2
+
+bb_3:                                             ; preds = %bb_5
+  br label %bb_4
+
+bb_4:                                             ; preds = %bb_3
+  %load_store_tmp11 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp11, ptr %local_18, align 8
+  %load_store_tmp12 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp12, ptr %local_19, align 8
+  %load_store_tmp13 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp13, ptr %local_20, align 8
+  %loaded_alloca14 = load ptr, ptr %local_18, align 8
+  %loaded_alloca15 = load i64, ptr %local_19, align 8
+  %loaded_alloca16 = load i64, ptr %local_20, align 8
+  call void @move_native_vector_swap(ptr @__move_rttydesc_u8, ptr %loaded_alloca14, i64 %loaded_alloca15, i64 %loaded_alloca16)
+  %load_store_tmp17 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp17, ptr %local_21, align 8
+  store i64 1, ptr %local_22, align 8
+  %add_src_0 = load i64, ptr %local_21, align 8
+  %add_src_1 = load i64, ptr %local_22, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond18 = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond18, label %then_bb19, label %join_bb20
+
+then_bb19:                                        ; preds = %bb_4
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb20:                                        ; preds = %bb_4
+  store i64 %add_dst, ptr %local_23, align 8
+  %load_store_tmp21 = load i64, ptr %local_23, align 8
+  store i64 %load_store_tmp21, ptr %local_2, align 8
+  %load_store_tmp22 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp22, ptr %local_24, align 8
+  store i64 1, ptr %local_25, align 8
+  %sub_src_023 = load i64, ptr %local_24, align 8
+  %sub_src_124 = load i64, ptr %local_25, align 8
+  %sub_dst25 = sub i64 %sub_src_023, %sub_src_124
+  %ovfcond26 = icmp ugt i64 %sub_dst25, %sub_src_023
+  br i1 %ovfcond26, label %then_bb27, label %join_bb28
+
+then_bb27:                                        ; preds = %join_bb20
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb28:                                        ; preds = %join_bb20
+  store i64 %sub_dst25, ptr %local_26, align 8
+  %load_store_tmp29 = load i64, ptr %local_26, align 8
+  store i64 %load_store_tmp29, ptr %local_1, align 8
+  br label %bb_5
+
+bb_2:                                             ; preds = %bb_5
+  %load_store_tmp30 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp30, ptr %local_27, align 8
+  ret void
+}
+
+declare i64 @move_native_vector_length(ptr, ptr)
+
+declare void @move_native_vector_swap(ptr, ptr, i64, i64)
+
+define %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %0) {
+entry:
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca %struct.bcs__BCS, align 8
+  store { ptr, i64, i64 } %0, ptr %local_0, align 8
+  store ptr %local_0, ptr %local_1, align 8
+  %call_arg_0 = load ptr, ptr %local_1, align 8
+  call void @"0000000000000001_vector_reverse_DYV9motnmmM5cs"(ptr %call_arg_0)
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_0, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_2__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_2__bytes, align 8
+  %insert_0 = insertvalue %struct.bcs__BCS undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.bcs__BCS %insert_0, ptr %local_3, align 8
+  %retval = load %struct.bcs__BCS, ptr %local_3, align 8
+  ret %struct.bcs__BCS %retval
+}
+
+define [32 x i8] @"0000000000000002_bcs_peel_address_6ieY385GfzQPhi"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4__bytes = alloca ptr, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca i1, align 1
+  %local_8 = alloca ptr, align 8
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca { ptr, i64, i64 }, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca i64, align 8
+  %local_13 = alloca i64, align 8
+  %local_14 = alloca i1, align 1
+  %local_15 = alloca ptr, align 8
+  %local_16 = alloca ptr, align 8
+  %local_17__bytes = alloca ptr, align 8
+  %local_18 = alloca i8, align 1
+  %local_19 = alloca i64, align 8
+  %local_20 = alloca i64, align 8
+  %local_21 = alloca i64, align 8
+  %local_22 = alloca ptr, align 8
+  %local_23 = alloca { ptr, i64, i64 }, align 8
+  %local_24 = alloca [32 x i8], align 1
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %tmp = load ptr, ptr %local_3, align 8
+  %fld_ref = getelementptr inbounds %struct.bcs__BCS, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_4__bytes, align 8
+  %loaded_alloca = load ptr, ptr %local_4__bytes, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_5, align 8
+  %retval1 = call i64 @"0000000000000002_address_length_85CkEAWyzLybDw"()
+  store i64 %retval1, ptr %local_6, align 8
+  %ge_src_0 = load i64, ptr %local_5, align 8
+  %ge_src_1 = load i64, ptr %local_6, align 8
+  %ge_dst = icmp uge i64 %ge_src_0, %ge_src_1
+  store i1 %ge_dst, ptr %local_7, align 1
+  %cnd = load i1, ptr %local_7, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp2 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp2, ptr %local_8, align 8
+  store i64 0, ptr %local_9, align 8
+  %call_arg_0 = load i64, ptr %local_9, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  %retval3 = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %retval3, ptr %local_10, align 8
+  store i64 0, ptr %local_11, align 8
+  %load_store_tmp4 = load i64, ptr %local_11, align 8
+  store i64 %load_store_tmp4, ptr %local_2, align 8
+  %load_store_tmp5 = load { ptr, i64, i64 }, ptr %local_10, align 8
+  store { ptr, i64, i64 } %load_store_tmp5, ptr %local_1, align 8
+  br label %bb_6
+
+bb_6:                                             ; preds = %join_bb, %bb_2
+  %load_store_tmp6 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp6, ptr %local_12, align 8
+  %retval7 = call i64 @"0000000000000002_address_length_85CkEAWyzLybDw"()
+  store i64 %retval7, ptr %local_13, align 8
+  %lt_src_0 = load i64, ptr %local_12, align 8
+  %lt_src_1 = load i64, ptr %local_13, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_14, align 1
+  %cnd8 = load i1, ptr %local_14, align 1
+  br i1 %cnd8, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_6
+  br label %bb_5
+
+bb_5:                                             ; preds = %bb_4
+  store ptr %local_1, ptr %local_15, align 8
+  %load_store_tmp9 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp9, ptr %local_16, align 8
+  %tmp10 = load ptr, ptr %local_16, align 8
+  %fld_ref11 = getelementptr inbounds %struct.bcs__BCS, ptr %tmp10, i32 0, i32 0
+  store ptr %fld_ref11, ptr %local_17__bytes, align 8
+  %loaded_alloca12 = load ptr, ptr %local_17__bytes, align 8
+  call void @move_native_vector_pop_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca12, ptr %local_18)
+  %loaded_alloca13 = load ptr, ptr %local_15, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca13, ptr %local_18)
+  %load_store_tmp14 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp14, ptr %local_19, align 8
+  store i64 1, ptr %local_20, align 8
+  %add_src_0 = load i64, ptr %local_19, align 8
+  %add_src_1 = load i64, ptr %local_20, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_5
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_5
+  store i64 %add_dst, ptr %local_21, align 8
+  %load_store_tmp15 = load i64, ptr %local_21, align 8
+  store i64 %load_store_tmp15, ptr %local_2, align 8
+  br label %bb_6
+
+bb_3:                                             ; preds = %bb_6
+  %load_store_tmp16 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp16, ptr %local_22, align 8
+  %load_store_tmp17 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp17, ptr %local_23, align 8
+  %retval18 = call [32 x i8] @move_native_address_from_bytes(ptr %local_23)
+  store [32 x i8] %retval18, ptr %local_24, align 1
+  %retval19 = load [32 x i8], ptr %local_24, align 1
+  ret [32 x i8] %retval19
+}
+
+declare i64 @"0000000000000002_address_length_85CkEAWyzLybDw"()
+
+declare { ptr, i64, i64 } @move_native_vector_empty(ptr)
+
+declare void @move_native_vector_pop_back(ptr, ptr, ptr)
+
+declare void @move_native_vector_push_back(ptr, ptr, ptr)
+
+declare [32 x i8] @move_native_address_from_bytes(ptr)
+
+define i1 @"0000000000000002_bcs_peel_bool_3uzNfP9g7KxJxU"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i1, align 1
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i8, align 1
+  %local_5 = alloca i8, align 1
+  %local_6 = alloca i8, align 1
+  %local_7 = alloca i1, align 1
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca i8, align 1
+  %local_10 = alloca i8, align 1
+  %local_11 = alloca i1, align 1
+  %local_12 = alloca i64, align 8
+  %local_13 = alloca i1, align 1
+  %local_14 = alloca i1, align 1
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %call_arg_0 = load ptr, ptr %local_3, align 8
+  %retval = call i8 @"0000000000000002_bcs_peel_u8_6d6AGS42yhTNFk"(ptr %call_arg_0)
+  store i8 %retval, ptr %local_4, align 1
+  %load_store_tmp1 = load i8, ptr %local_4, align 1
+  store i8 %load_store_tmp1, ptr %local_2, align 1
+  %load_store_tmp2 = load i8, ptr %local_2, align 1
+  store i8 %load_store_tmp2, ptr %local_5, align 1
+  store i8 0, ptr %local_6, align 1
+  %eq_src_0 = load i8, ptr %local_5, align 1
+  %eq_src_1 = load i8, ptr %local_6, align 1
+  %eq_dst = icmp eq i8 %eq_src_0, %eq_src_1
+  store i1 %eq_dst, ptr %local_7, align 1
+  %cnd = load i1, ptr %local_7, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  store i1 false, ptr %local_8, align 1
+  %load_store_tmp3 = load i1, ptr %local_8, align 1
+  store i1 %load_store_tmp3, ptr %local_1, align 1
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp4 = load i8, ptr %local_2, align 1
+  store i8 %load_store_tmp4, ptr %local_9, align 1
+  store i8 1, ptr %local_10, align 1
+  %eq_src_05 = load i8, ptr %local_9, align 1
+  %eq_src_16 = load i8, ptr %local_10, align 1
+  %eq_dst7 = icmp eq i8 %eq_src_05, %eq_src_16
+  store i1 %eq_dst7, ptr %local_11, align 1
+  %cnd8 = load i1, ptr %local_11, align 1
+  br i1 %cnd8, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_0
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_0
+  store i64 1, ptr %local_12, align 8
+  %call_arg_09 = load i64, ptr %local_12, align 8
+  call void @move_rt_abort(i64 %call_arg_09)
+  unreachable
+
+bb_5:                                             ; preds = %bb_4
+  store i1 true, ptr %local_13, align 1
+  %load_store_tmp10 = load i1, ptr %local_13, align 1
+  store i1 %load_store_tmp10, ptr %local_1, align 1
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_5, %bb_1
+  %load_store_tmp11 = load i1, ptr %local_1, align 1
+  store i1 %load_store_tmp11, ptr %local_14, align 1
+  %retval12 = load i1, ptr %local_14, align 1
+  ret i1 %retval12
+}
+
+define i8 @"0000000000000002_bcs_peel_u8_6d6AGS42yhTNFk"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2__bytes = alloca ptr, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca i64, align 8
+  %local_5 = alloca i1, align 1
+  %local_6 = alloca ptr, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca ptr, align 8
+  %local_9__bytes = alloca ptr, align 8
+  %local_10 = alloca i8, align 1
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %tmp = load ptr, ptr %local_1, align 8
+  %fld_ref = getelementptr inbounds %struct.bcs__BCS, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_2__bytes, align 8
+  %loaded_alloca = load ptr, ptr %local_2__bytes, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_3, align 8
+  store i64 1, ptr %local_4, align 8
+  %ge_src_0 = load i64, ptr %local_3, align 8
+  %ge_src_1 = load i64, ptr %local_4, align 8
+  %ge_dst = icmp uge i64 %ge_src_0, %ge_src_1
+  store i1 %ge_dst, ptr %local_5, align 1
+  %cnd = load i1, ptr %local_5, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_6, align 8
+  store i64 0, ptr %local_7, align 8
+  %call_arg_0 = load i64, ptr %local_7, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  %load_store_tmp2 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp2, ptr %local_8, align 8
+  %tmp3 = load ptr, ptr %local_8, align 8
+  %fld_ref4 = getelementptr inbounds %struct.bcs__BCS, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_9__bytes, align 8
+  %loaded_alloca5 = load ptr, ptr %local_9__bytes, align 8
+  call void @move_native_vector_pop_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca5, ptr %local_10)
+  %retval6 = load i8, ptr %local_10, align 1
+  ret i8 %retval6
+}
+
+define %struct.option__Option_address_ @"0000000000000002_bcs_peel_option_add_3CPk1XLtV1YCnh"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca %struct.option__Option_address_, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca [32 x i8], align 1
+  %local_6 = alloca %struct.option__Option_address_, align 8
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca %struct.option__Option_address_, align 8
+  %local_9 = alloca %struct.option__Option_address_, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_2, align 8
+  %call_arg_0 = load ptr, ptr %local_2, align 8
+  %retval = call i1 @"0000000000000002_bcs_peel_bool_3uzNfP9g7KxJxU"(ptr %call_arg_0)
+  store i1 %retval, ptr %local_3, align 1
+  %cnd = load i1, ptr %local_3, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_02 = load ptr, ptr %local_4, align 8
+  %retval3 = call [32 x i8] @"0000000000000002_bcs_peel_address_6ieY385GfzQPhi"(ptr %call_arg_02)
+  store [32 x i8] %retval3, ptr %local_5, align 1
+  %call_arg_04 = load [32 x i8], ptr %local_5, align 1
+  %retval5 = call %struct.option__Option_address_ @"0000000000000001_option_some_CDdPcTrWutT5hX"([32 x i8] %call_arg_04)
+  store %struct.option__Option_address_ %retval5, ptr %local_6, align 8
+  %load_store_tmp6 = load %struct.option__Option_address_, ptr %local_6, align 8
+  store %struct.option__Option_address_ %load_store_tmp6, ptr %local_1, align 8
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp7 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp7, ptr %local_7, align 8
+  %retval8 = call %struct.option__Option_address_ @"0000000000000001_option_none_85Lm9pYFBW1PXV"()
+  store %struct.option__Option_address_ %retval8, ptr %local_8, align 8
+  %load_store_tmp9 = load %struct.option__Option_address_, ptr %local_8, align 8
+  store %struct.option__Option_address_ %load_store_tmp9, ptr %local_1, align 8
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_0, %bb_1
+  %retval10 = load %struct.option__Option_address_, ptr %local_1, align 8
+  ret %struct.option__Option_address_ %retval10
+}
+
+define private %struct.option__Option_address_ @"0000000000000001_option_some_CDdPcTrWutT5hX"([32 x i8] %0) {
+entry:
+  %local_0 = alloca [32 x i8], align 1
+  %local_1 = alloca [32 x i8], align 1
+  %local_2__vec = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca %struct.option__Option_address_, align 8
+  store [32 x i8] %0, ptr %local_0, align 1
+  %call_arg_0 = load [32 x i8], ptr %local_0, align 1
+  %retval = call { ptr, i64, i64 } @"0000000000000001_vector_singleton_EqL6jZVu5mXJRh"([32 x i8] %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_2__vec, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_2__vec, align 8
+  %insert_0 = insertvalue %struct.option__Option_address_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.option__Option_address_ %insert_0, ptr %local_3, align 8
+  %retval1 = load %struct.option__Option_address_, ptr %local_3, align 8
+  ret %struct.option__Option_address_ %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000001_vector_singleton_EqL6jZVu5mXJRh"([32 x i8] %0) {
+entry:
+  %local_0 = alloca [32 x i8], align 1
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca [32 x i8], align 1
+  %local_5 = alloca { ptr, i64, i64 }, align 8
+  store [32 x i8] %0, ptr %local_0, align 1
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_address)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_2, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_3, align 8
+  %loaded_alloca = load ptr, ptr %local_3, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_address, ptr %loaded_alloca, ptr %local_0)
+  %load_store_tmp1 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp1, ptr %local_5, align 8
+  %retval2 = load { ptr, i64, i64 }, ptr %local_5, align 8
+  ret { ptr, i64, i64 } %retval2
+}
+
+define private %struct.option__Option_address_ @"0000000000000001_option_none_85Lm9pYFBW1PXV"() {
+entry:
+  %local_0__vec = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca %struct.option__Option_address_, align 8
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_address)
+  store { ptr, i64, i64 } %retval, ptr %local_0__vec, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_0__vec, align 8
+  %insert_0 = insertvalue %struct.option__Option_address_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.option__Option_address_ %insert_0, ptr %local_1, align 8
+  %retval1 = load %struct.option__Option_address_, ptr %local_1, align 8
+  ret %struct.option__Option_address_ %retval1
+}
+
+define %struct.option__Option_bool_ @"0000000000000002_bcs_peel_option_boo_4RJsKiXKvzRAXW"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca %struct.option__Option_bool_, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca i1, align 1
+  %local_6 = alloca %struct.option__Option_bool_, align 8
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca %struct.option__Option_bool_, align 8
+  %local_9 = alloca %struct.option__Option_bool_, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_2, align 8
+  %call_arg_0 = load ptr, ptr %local_2, align 8
+  %retval = call i1 @"0000000000000002_bcs_peel_bool_3uzNfP9g7KxJxU"(ptr %call_arg_0)
+  store i1 %retval, ptr %local_3, align 1
+  %cnd = load i1, ptr %local_3, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_02 = load ptr, ptr %local_4, align 8
+  %retval3 = call i1 @"0000000000000002_bcs_peel_bool_3uzNfP9g7KxJxU"(ptr %call_arg_02)
+  store i1 %retval3, ptr %local_5, align 1
+  %call_arg_04 = load i1, ptr %local_5, align 1
+  %retval5 = call %struct.option__Option_bool_ @"0000000000000001_option_some_Ao9SKJoXum3yE1"(i1 %call_arg_04)
+  store %struct.option__Option_bool_ %retval5, ptr %local_6, align 8
+  %load_store_tmp6 = load %struct.option__Option_bool_, ptr %local_6, align 8
+  store %struct.option__Option_bool_ %load_store_tmp6, ptr %local_1, align 8
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp7 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp7, ptr %local_7, align 8
+  %retval8 = call %struct.option__Option_bool_ @"0000000000000001_option_none_HcJFTKMJvLKwdo"()
+  store %struct.option__Option_bool_ %retval8, ptr %local_8, align 8
+  %load_store_tmp9 = load %struct.option__Option_bool_, ptr %local_8, align 8
+  store %struct.option__Option_bool_ %load_store_tmp9, ptr %local_1, align 8
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_0, %bb_1
+  %retval10 = load %struct.option__Option_bool_, ptr %local_1, align 8
+  ret %struct.option__Option_bool_ %retval10
+}
+
+define private %struct.option__Option_bool_ @"0000000000000001_option_some_Ao9SKJoXum3yE1"(i1 %0) {
+entry:
+  %local_0 = alloca i1, align 1
+  %local_1 = alloca i1, align 1
+  %local_2__vec = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca %struct.option__Option_bool_, align 8
+  store i1 %0, ptr %local_0, align 1
+  %load_store_tmp = load i1, ptr %local_0, align 1
+  store i1 %load_store_tmp, ptr %local_1, align 1
+  %call_arg_0 = load i1, ptr %local_1, align 1
+  %retval = call { ptr, i64, i64 } @"0000000000000001_vector_singleton_CuhCuha5pBKsvq"(i1 %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_2__vec, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_2__vec, align 8
+  %insert_0 = insertvalue %struct.option__Option_bool_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.option__Option_bool_ %insert_0, ptr %local_3, align 8
+  %retval1 = load %struct.option__Option_bool_, ptr %local_3, align 8
+  ret %struct.option__Option_bool_ %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000001_vector_singleton_CuhCuha5pBKsvq"(i1 %0) {
+entry:
+  %local_0 = alloca i1, align 1
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca { ptr, i64, i64 }, align 8
+  store i1 %0, ptr %local_0, align 1
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_bool)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_2, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_3, align 8
+  %load_store_tmp1 = load i1, ptr %local_0, align 1
+  store i1 %load_store_tmp1, ptr %local_4, align 1
+  %loaded_alloca = load ptr, ptr %local_3, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_bool, ptr %loaded_alloca, ptr %local_4)
+  %load_store_tmp2 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp2, ptr %local_5, align 8
+  %retval3 = load { ptr, i64, i64 }, ptr %local_5, align 8
+  ret { ptr, i64, i64 } %retval3
+}
+
+define private %struct.option__Option_bool_ @"0000000000000001_option_none_HcJFTKMJvLKwdo"() {
+entry:
+  %local_0__vec = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca %struct.option__Option_bool_, align 8
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_bool)
+  store { ptr, i64, i64 } %retval, ptr %local_0__vec, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_0__vec, align 8
+  %insert_0 = insertvalue %struct.option__Option_bool_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.option__Option_bool_ %insert_0, ptr %local_1, align 8
+  %retval1 = load %struct.option__Option_bool_, ptr %local_1, align 8
+  ret %struct.option__Option_bool_ %retval1
+}
+
+define %struct.option__Option_u128_ @"0000000000000002_bcs_peel_option_u12_C6eBmktECftBLv"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca %struct.option__Option_u128_, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca i128, align 8
+  %local_6 = alloca %struct.option__Option_u128_, align 8
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca %struct.option__Option_u128_, align 8
+  %local_9 = alloca %struct.option__Option_u128_, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_2, align 8
+  %call_arg_0 = load ptr, ptr %local_2, align 8
+  %retval = call i1 @"0000000000000002_bcs_peel_bool_3uzNfP9g7KxJxU"(ptr %call_arg_0)
+  store i1 %retval, ptr %local_3, align 1
+  %cnd = load i1, ptr %local_3, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_02 = load ptr, ptr %local_4, align 8
+  %retval3 = call i128 @"0000000000000002_bcs_peel_u128_NmHT5JzgtEzTCJ"(ptr %call_arg_02)
+  store i128 %retval3, ptr %local_5, align 8
+  %call_arg_04 = load i128, ptr %local_5, align 8
+  %retval5 = call %struct.option__Option_u128_ @"0000000000000001_option_some_7TwgxN8n15ac7N"(i128 %call_arg_04)
+  store %struct.option__Option_u128_ %retval5, ptr %local_6, align 8
+  %load_store_tmp6 = load %struct.option__Option_u128_, ptr %local_6, align 8
+  store %struct.option__Option_u128_ %load_store_tmp6, ptr %local_1, align 8
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp7 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp7, ptr %local_7, align 8
+  %retval8 = call %struct.option__Option_u128_ @"0000000000000001_option_none_3HHBciYin6moFj"()
+  store %struct.option__Option_u128_ %retval8, ptr %local_8, align 8
+  %load_store_tmp9 = load %struct.option__Option_u128_, ptr %local_8, align 8
+  store %struct.option__Option_u128_ %load_store_tmp9, ptr %local_1, align 8
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_0, %bb_1
+  %retval10 = load %struct.option__Option_u128_, ptr %local_1, align 8
+  ret %struct.option__Option_u128_ %retval10
+}
+
+define i128 @"0000000000000002_bcs_peel_u128_NmHT5JzgtEzTCJ"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i128, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca i128, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca ptr, align 8
+  %local_10 = alloca i64, align 8
+  %local_11 = alloca i128, align 8
+  %local_12 = alloca i8, align 1
+  %local_13 = alloca i8, align 1
+  %local_14 = alloca i8, align 1
+  %local_15 = alloca i1, align 1
+  %local_16 = alloca ptr, align 8
+  %local_17__bytes = alloca ptr, align 8
+  %local_18 = alloca i8, align 1
+  %local_19 = alloca i128, align 8
+  %local_20 = alloca i128, align 8
+  %local_21 = alloca i128, align 8
+  %local_22 = alloca i8, align 1
+  %local_23 = alloca i128, align 8
+  %local_24 = alloca i128, align 8
+  %local_25 = alloca i8, align 1
+  %local_26 = alloca i8, align 1
+  %local_27 = alloca i8, align 1
+  %local_28 = alloca ptr, align 8
+  %local_29 = alloca i128, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.bcs__BCS, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %loaded_alloca = load ptr, ptr %local_5__bytes, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_6, align 8
+  store i64 16, ptr %local_7, align 8
+  %ge_src_0 = load i64, ptr %local_6, align 8
+  %ge_src_1 = load i64, ptr %local_7, align 8
+  %ge_dst = icmp uge i64 %ge_src_0, %ge_src_1
+  store i1 %ge_dst, ptr %local_8, align 1
+  %cnd = load i1, ptr %local_8, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_9, align 8
+  store i64 0, ptr %local_10, align 8
+  %call_arg_0 = load i64, ptr %local_10, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  store i128 0, ptr %local_11, align 8
+  store i8 0, ptr %local_12, align 1
+  %load_store_tmp2 = load i8, ptr %local_12, align 1
+  store i8 %load_store_tmp2, ptr %local_2, align 1
+  %load_store_tmp3 = load i128, ptr %local_11, align 8
+  store i128 %load_store_tmp3, ptr %local_3, align 8
+  br label %bb_6
+
+bb_6:                                             ; preds = %join_bb24, %bb_2
+  %load_store_tmp4 = load i8, ptr %local_2, align 1
+  store i8 %load_store_tmp4, ptr %local_13, align 1
+  store i8 -128, ptr %local_14, align 1
+  %lt_src_0 = load i8, ptr %local_13, align 1
+  %lt_src_1 = load i8, ptr %local_14, align 1
+  %lt_dst = icmp ult i8 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_15, align 1
+  %cnd5 = load i1, ptr %local_15, align 1
+  br i1 %cnd5, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_6
+  br label %bb_5
+
+bb_5:                                             ; preds = %bb_4
+  %load_store_tmp6 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp6, ptr %local_16, align 8
+  %tmp7 = load ptr, ptr %local_16, align 8
+  %fld_ref8 = getelementptr inbounds %struct.bcs__BCS, ptr %tmp7, i32 0, i32 0
+  store ptr %fld_ref8, ptr %local_17__bytes, align 8
+  %loaded_alloca9 = load ptr, ptr %local_17__bytes, align 8
+  call void @move_native_vector_pop_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca9, ptr %local_18)
+  %cast_src = load i8, ptr %local_18, align 1
+  %zext_dst = zext i8 %cast_src to i128
+  store i128 %zext_dst, ptr %local_19, align 8
+  %load_store_tmp10 = load i128, ptr %local_19, align 8
+  store i128 %load_store_tmp10, ptr %local_1, align 8
+  %load_store_tmp11 = load i128, ptr %local_3, align 8
+  store i128 %load_store_tmp11, ptr %local_20, align 8
+  %load_store_tmp12 = load i128, ptr %local_1, align 8
+  store i128 %load_store_tmp12, ptr %local_21, align 8
+  %load_store_tmp13 = load i8, ptr %local_2, align 1
+  store i8 %load_store_tmp13, ptr %local_22, align 1
+  %shl_src_0 = load i128, ptr %local_21, align 8
+  %shl_src_1 = load i8, ptr %local_22, align 1
+  %rangecond = icmp uge i8 %shl_src_1, -128
+  br i1 %rangecond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_5
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_5
+  %zext_dst14 = zext i8 %shl_src_1 to i128
+  %shl_dst = shl i128 %shl_src_0, %zext_dst14
+  store i128 %shl_dst, ptr %local_23, align 8
+  %add_src_0 = load i128, ptr %local_20, align 8
+  %add_src_1 = load i128, ptr %local_23, align 8
+  %add_dst = add i128 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i128 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb15, label %join_bb16
+
+then_bb15:                                        ; preds = %join_bb
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb16:                                        ; preds = %join_bb
+  store i128 %add_dst, ptr %local_24, align 8
+  %load_store_tmp17 = load i128, ptr %local_24, align 8
+  store i128 %load_store_tmp17, ptr %local_3, align 8
+  %load_store_tmp18 = load i8, ptr %local_2, align 1
+  store i8 %load_store_tmp18, ptr %local_25, align 1
+  store i8 8, ptr %local_26, align 1
+  %add_src_019 = load i8, ptr %local_25, align 1
+  %add_src_120 = load i8, ptr %local_26, align 1
+  %add_dst21 = add i8 %add_src_019, %add_src_120
+  %ovfcond22 = icmp ult i8 %add_dst21, %add_src_019
+  br i1 %ovfcond22, label %then_bb23, label %join_bb24
+
+then_bb23:                                        ; preds = %join_bb16
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb24:                                        ; preds = %join_bb16
+  store i8 %add_dst21, ptr %local_27, align 1
+  %load_store_tmp25 = load i8, ptr %local_27, align 1
+  store i8 %load_store_tmp25, ptr %local_2, align 1
+  br label %bb_6
+
+bb_3:                                             ; preds = %bb_6
+  %load_store_tmp26 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp26, ptr %local_28, align 8
+  %load_store_tmp27 = load i128, ptr %local_3, align 8
+  store i128 %load_store_tmp27, ptr %local_29, align 8
+  %retval28 = load i128, ptr %local_29, align 8
+  ret i128 %retval28
+}
+
+define private %struct.option__Option_u128_ @"0000000000000001_option_some_7TwgxN8n15ac7N"(i128 %0) {
+entry:
+  %local_0 = alloca i128, align 8
+  %local_1 = alloca i128, align 8
+  %local_2__vec = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca %struct.option__Option_u128_, align 8
+  store i128 %0, ptr %local_0, align 8
+  %load_store_tmp = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp, ptr %local_1, align 8
+  %call_arg_0 = load i128, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000001_vector_singleton_J39YvSwf3VT3iv"(i128 %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_2__vec, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_2__vec, align 8
+  %insert_0 = insertvalue %struct.option__Option_u128_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.option__Option_u128_ %insert_0, ptr %local_3, align 8
+  %retval1 = load %struct.option__Option_u128_, ptr %local_3, align 8
+  ret %struct.option__Option_u128_ %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000001_vector_singleton_J39YvSwf3VT3iv"(i128 %0) {
+entry:
+  %local_0 = alloca i128, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i128, align 8
+  %local_5 = alloca { ptr, i64, i64 }, align 8
+  store i128 %0, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_u128)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_2, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_3, align 8
+  %load_store_tmp1 = load i128, ptr %local_0, align 8
+  store i128 %load_store_tmp1, ptr %local_4, align 8
+  %loaded_alloca = load ptr, ptr %local_3, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u128, ptr %loaded_alloca, ptr %local_4)
+  %load_store_tmp2 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp2, ptr %local_5, align 8
+  %retval3 = load { ptr, i64, i64 }, ptr %local_5, align 8
+  ret { ptr, i64, i64 } %retval3
+}
+
+define private %struct.option__Option_u128_ @"0000000000000001_option_none_3HHBciYin6moFj"() {
+entry:
+  %local_0__vec = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca %struct.option__Option_u128_, align 8
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_u128)
+  store { ptr, i64, i64 } %retval, ptr %local_0__vec, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_0__vec, align 8
+  %insert_0 = insertvalue %struct.option__Option_u128_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.option__Option_u128_ %insert_0, ptr %local_1, align 8
+  %retval1 = load %struct.option__Option_u128_, ptr %local_1, align 8
+  ret %struct.option__Option_u128_ %retval1
+}
+
+define %struct.option__Option_u64_ @"0000000000000002_bcs_peel_option_u64_3WJk1T5bFj4c67"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca %struct.option__Option_u64_, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca %struct.option__Option_u64_, align 8
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca %struct.option__Option_u64_, align 8
+  %local_9 = alloca %struct.option__Option_u64_, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_2, align 8
+  %call_arg_0 = load ptr, ptr %local_2, align 8
+  %retval = call i1 @"0000000000000002_bcs_peel_bool_3uzNfP9g7KxJxU"(ptr %call_arg_0)
+  store i1 %retval, ptr %local_3, align 1
+  %cnd = load i1, ptr %local_3, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_02 = load ptr, ptr %local_4, align 8
+  %retval3 = call i64 @"0000000000000002_bcs_peel_u64_AL793VCQ2sZbgn"(ptr %call_arg_02)
+  store i64 %retval3, ptr %local_5, align 8
+  %call_arg_04 = load i64, ptr %local_5, align 8
+  %retval5 = call %struct.option__Option_u64_ @"0000000000000001_option_some_4zz2TymghHW1fs"(i64 %call_arg_04)
+  store %struct.option__Option_u64_ %retval5, ptr %local_6, align 8
+  %load_store_tmp6 = load %struct.option__Option_u64_, ptr %local_6, align 8
+  store %struct.option__Option_u64_ %load_store_tmp6, ptr %local_1, align 8
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp7 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp7, ptr %local_7, align 8
+  %retval8 = call %struct.option__Option_u64_ @"0000000000000001_option_none_5gpVRKyNEVsuL3"()
+  store %struct.option__Option_u64_ %retval8, ptr %local_8, align 8
+  %load_store_tmp9 = load %struct.option__Option_u64_, ptr %local_8, align 8
+  store %struct.option__Option_u64_ %load_store_tmp9, ptr %local_1, align 8
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_0, %bb_1
+  %retval10 = load %struct.option__Option_u64_, ptr %local_1, align 8
+  ret %struct.option__Option_u64_ %retval10
+}
+
+define i64 @"0000000000000002_bcs_peel_u64_AL793VCQ2sZbgn"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca ptr, align 8
+  %local_10 = alloca i64, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca i8, align 1
+  %local_13 = alloca i8, align 1
+  %local_14 = alloca i8, align 1
+  %local_15 = alloca i1, align 1
+  %local_16 = alloca ptr, align 8
+  %local_17__bytes = alloca ptr, align 8
+  %local_18 = alloca i8, align 1
+  %local_19 = alloca i64, align 8
+  %local_20 = alloca i64, align 8
+  %local_21 = alloca i64, align 8
+  %local_22 = alloca i8, align 1
+  %local_23 = alloca i64, align 8
+  %local_24 = alloca i64, align 8
+  %local_25 = alloca i8, align 1
+  %local_26 = alloca i8, align 1
+  %local_27 = alloca i8, align 1
+  %local_28 = alloca ptr, align 8
+  %local_29 = alloca i64, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.bcs__BCS, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %loaded_alloca = load ptr, ptr %local_5__bytes, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_6, align 8
+  store i64 8, ptr %local_7, align 8
+  %ge_src_0 = load i64, ptr %local_6, align 8
+  %ge_src_1 = load i64, ptr %local_7, align 8
+  %ge_dst = icmp uge i64 %ge_src_0, %ge_src_1
+  store i1 %ge_dst, ptr %local_8, align 1
+  %cnd = load i1, ptr %local_8, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_9, align 8
+  store i64 0, ptr %local_10, align 8
+  %call_arg_0 = load i64, ptr %local_10, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  store i64 0, ptr %local_11, align 8
+  store i8 0, ptr %local_12, align 1
+  %load_store_tmp2 = load i8, ptr %local_12, align 1
+  store i8 %load_store_tmp2, ptr %local_2, align 1
+  %load_store_tmp3 = load i64, ptr %local_11, align 8
+  store i64 %load_store_tmp3, ptr %local_3, align 8
+  br label %bb_6
+
+bb_6:                                             ; preds = %join_bb24, %bb_2
+  %load_store_tmp4 = load i8, ptr %local_2, align 1
+  store i8 %load_store_tmp4, ptr %local_13, align 1
+  store i8 64, ptr %local_14, align 1
+  %lt_src_0 = load i8, ptr %local_13, align 1
+  %lt_src_1 = load i8, ptr %local_14, align 1
+  %lt_dst = icmp ult i8 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_15, align 1
+  %cnd5 = load i1, ptr %local_15, align 1
+  br i1 %cnd5, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_6
+  br label %bb_5
+
+bb_5:                                             ; preds = %bb_4
+  %load_store_tmp6 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp6, ptr %local_16, align 8
+  %tmp7 = load ptr, ptr %local_16, align 8
+  %fld_ref8 = getelementptr inbounds %struct.bcs__BCS, ptr %tmp7, i32 0, i32 0
+  store ptr %fld_ref8, ptr %local_17__bytes, align 8
+  %loaded_alloca9 = load ptr, ptr %local_17__bytes, align 8
+  call void @move_native_vector_pop_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca9, ptr %local_18)
+  %cast_src = load i8, ptr %local_18, align 1
+  %zext_dst = zext i8 %cast_src to i64
+  store i64 %zext_dst, ptr %local_19, align 8
+  %load_store_tmp10 = load i64, ptr %local_19, align 8
+  store i64 %load_store_tmp10, ptr %local_1, align 8
+  %load_store_tmp11 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp11, ptr %local_20, align 8
+  %load_store_tmp12 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp12, ptr %local_21, align 8
+  %load_store_tmp13 = load i8, ptr %local_2, align 1
+  store i8 %load_store_tmp13, ptr %local_22, align 1
+  %shl_src_0 = load i64, ptr %local_21, align 8
+  %shl_src_1 = load i8, ptr %local_22, align 1
+  %rangecond = icmp uge i8 %shl_src_1, 64
+  br i1 %rangecond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_5
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_5
+  %zext_dst14 = zext i8 %shl_src_1 to i64
+  %shl_dst = shl i64 %shl_src_0, %zext_dst14
+  store i64 %shl_dst, ptr %local_23, align 8
+  %add_src_0 = load i64, ptr %local_20, align 8
+  %add_src_1 = load i64, ptr %local_23, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb15, label %join_bb16
+
+then_bb15:                                        ; preds = %join_bb
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb16:                                        ; preds = %join_bb
+  store i64 %add_dst, ptr %local_24, align 8
+  %load_store_tmp17 = load i64, ptr %local_24, align 8
+  store i64 %load_store_tmp17, ptr %local_3, align 8
+  %load_store_tmp18 = load i8, ptr %local_2, align 1
+  store i8 %load_store_tmp18, ptr %local_25, align 1
+  store i8 8, ptr %local_26, align 1
+  %add_src_019 = load i8, ptr %local_25, align 1
+  %add_src_120 = load i8, ptr %local_26, align 1
+  %add_dst21 = add i8 %add_src_019, %add_src_120
+  %ovfcond22 = icmp ult i8 %add_dst21, %add_src_019
+  br i1 %ovfcond22, label %then_bb23, label %join_bb24
+
+then_bb23:                                        ; preds = %join_bb16
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb24:                                        ; preds = %join_bb16
+  store i8 %add_dst21, ptr %local_27, align 1
+  %load_store_tmp25 = load i8, ptr %local_27, align 1
+  store i8 %load_store_tmp25, ptr %local_2, align 1
+  br label %bb_6
+
+bb_3:                                             ; preds = %bb_6
+  %load_store_tmp26 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp26, ptr %local_28, align 8
+  %load_store_tmp27 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp27, ptr %local_29, align 8
+  %retval28 = load i64, ptr %local_29, align 8
+  ret i64 %retval28
+}
+
+define private %struct.option__Option_u64_ @"0000000000000001_option_some_4zz2TymghHW1fs"(i64 %0) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2__vec = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca %struct.option__Option_u64_, align 8
+  store i64 %0, ptr %local_0, align 8
+  %load_store_tmp = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp, ptr %local_1, align 8
+  %call_arg_0 = load i64, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000001_vector_singleton_8XKRmxA9XBmXWD"(i64 %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_2__vec, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_2__vec, align 8
+  %insert_0 = insertvalue %struct.option__Option_u64_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.option__Option_u64_ %insert_0, ptr %local_3, align 8
+  %retval1 = load %struct.option__Option_u64_, ptr %local_3, align 8
+  ret %struct.option__Option_u64_ %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000001_vector_singleton_8XKRmxA9XBmXWD"(i64 %0) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i64, align 8
+  %local_5 = alloca { ptr, i64, i64 }, align 8
+  store i64 %0, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_u64)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_2, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_3, align 8
+  %load_store_tmp1 = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp1, ptr %local_4, align 8
+  %loaded_alloca = load ptr, ptr %local_3, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u64, ptr %loaded_alloca, ptr %local_4)
+  %load_store_tmp2 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp2, ptr %local_5, align 8
+  %retval3 = load { ptr, i64, i64 }, ptr %local_5, align 8
+  ret { ptr, i64, i64 } %retval3
+}
+
+define private %struct.option__Option_u64_ @"0000000000000001_option_none_5gpVRKyNEVsuL3"() {
+entry:
+  %local_0__vec = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca %struct.option__Option_u64_, align 8
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_u64)
+  store { ptr, i64, i64 } %retval, ptr %local_0__vec, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_0__vec, align 8
+  %insert_0 = insertvalue %struct.option__Option_u64_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.option__Option_u64_ %insert_0, ptr %local_1, align 8
+  %retval1 = load %struct.option__Option_u64_, ptr %local_1, align 8
+  ret %struct.option__Option_u64_ %retval1
+}
+
+define %struct.option__Option_u8_ @"0000000000000002_bcs_peel_option_u8_CHXhFou58tDHFw"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca %struct.option__Option_u8_, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca i8, align 1
+  %local_6 = alloca %struct.option__Option_u8_, align 8
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca %struct.option__Option_u8_, align 8
+  %local_9 = alloca %struct.option__Option_u8_, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_2, align 8
+  %call_arg_0 = load ptr, ptr %local_2, align 8
+  %retval = call i1 @"0000000000000002_bcs_peel_bool_3uzNfP9g7KxJxU"(ptr %call_arg_0)
+  store i1 %retval, ptr %local_3, align 1
+  %cnd = load i1, ptr %local_3, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_02 = load ptr, ptr %local_4, align 8
+  %retval3 = call i8 @"0000000000000002_bcs_peel_u8_6d6AGS42yhTNFk"(ptr %call_arg_02)
+  store i8 %retval3, ptr %local_5, align 1
+  %call_arg_04 = load i8, ptr %local_5, align 1
+  %retval5 = call %struct.option__Option_u8_ @"0000000000000001_option_some_xnTx4LiMbuArQQ"(i8 %call_arg_04)
+  store %struct.option__Option_u8_ %retval5, ptr %local_6, align 8
+  %load_store_tmp6 = load %struct.option__Option_u8_, ptr %local_6, align 8
+  store %struct.option__Option_u8_ %load_store_tmp6, ptr %local_1, align 8
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp7 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp7, ptr %local_7, align 8
+  %retval8 = call %struct.option__Option_u8_ @"0000000000000001_option_none_FphftULLau4Zg2"()
+  store %struct.option__Option_u8_ %retval8, ptr %local_8, align 8
+  %load_store_tmp9 = load %struct.option__Option_u8_, ptr %local_8, align 8
+  store %struct.option__Option_u8_ %load_store_tmp9, ptr %local_1, align 8
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_0, %bb_1
+  %retval10 = load %struct.option__Option_u8_, ptr %local_1, align 8
+  ret %struct.option__Option_u8_ %retval10
+}
+
+define private %struct.option__Option_u8_ @"0000000000000001_option_some_xnTx4LiMbuArQQ"(i8 %0) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i8, align 1
+  %local_2__vec = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca %struct.option__Option_u8_, align 8
+  store i8 %0, ptr %local_0, align 1
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_1, align 1
+  %call_arg_0 = load i8, ptr %local_1, align 1
+  %retval = call { ptr, i64, i64 } @"0000000000000001_vector_singleton_DCWunrxSPXPExo"(i8 %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_2__vec, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_2__vec, align 8
+  %insert_0 = insertvalue %struct.option__Option_u8_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.option__Option_u8_ %insert_0, ptr %local_3, align 8
+  %retval1 = load %struct.option__Option_u8_, ptr %local_3, align 8
+  ret %struct.option__Option_u8_ %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000001_vector_singleton_DCWunrxSPXPExo"(i8 %0) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i8, align 1
+  %local_5 = alloca { ptr, i64, i64 }, align 8
+  store i8 %0, ptr %local_0, align 1
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_2, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_3, align 8
+  %load_store_tmp1 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp1, ptr %local_4, align 1
+  %loaded_alloca = load ptr, ptr %local_3, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca, ptr %local_4)
+  %load_store_tmp2 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp2, ptr %local_5, align 8
+  %retval3 = load { ptr, i64, i64 }, ptr %local_5, align 8
+  ret { ptr, i64, i64 } %retval3
+}
+
+define private %struct.option__Option_u8_ @"0000000000000001_option_none_FphftULLau4Zg2"() {
+entry:
+  %local_0__vec = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca %struct.option__Option_u8_, align 8
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %retval, ptr %local_0__vec, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_0__vec, align 8
+  %insert_0 = insertvalue %struct.option__Option_u8_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.option__Option_u8_ %insert_0, ptr %local_1, align 8
+  %retval1 = load %struct.option__Option_u8_, ptr %local_1, align 8
+  ret %struct.option__Option_u8_ %retval1
+}
+
+define i256 @"0000000000000002_bcs_peel_u256_5D9dbVt6W5MyPc"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i256, align 8
+  %local_2 = alloca i16, align 2
+  %local_3 = alloca i256, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca ptr, align 8
+  %local_10 = alloca i64, align 8
+  %local_11 = alloca i256, align 8
+  %local_12 = alloca i16, align 2
+  %local_13 = alloca i16, align 2
+  %local_14 = alloca i16, align 2
+  %local_15 = alloca i1, align 1
+  %local_16 = alloca ptr, align 8
+  %local_17__bytes = alloca ptr, align 8
+  %local_18 = alloca i8, align 1
+  %local_19 = alloca i256, align 8
+  %local_20 = alloca i256, align 8
+  %local_21 = alloca i256, align 8
+  %local_22 = alloca i16, align 2
+  %local_23 = alloca i8, align 1
+  %local_24 = alloca i256, align 8
+  %local_25 = alloca i256, align 8
+  %local_26 = alloca i16, align 2
+  %local_27 = alloca i16, align 2
+  %local_28 = alloca i16, align 2
+  %local_29 = alloca ptr, align 8
+  %local_30 = alloca i256, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.bcs__BCS, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %loaded_alloca = load ptr, ptr %local_5__bytes, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_6, align 8
+  store i64 32, ptr %local_7, align 8
+  %ge_src_0 = load i64, ptr %local_6, align 8
+  %ge_src_1 = load i64, ptr %local_7, align 8
+  %ge_dst = icmp uge i64 %ge_src_0, %ge_src_1
+  store i1 %ge_dst, ptr %local_8, align 1
+  %cnd = load i1, ptr %local_8, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_9, align 8
+  store i64 0, ptr %local_10, align 8
+  %call_arg_0 = load i64, ptr %local_10, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  store i256 0, ptr %local_11, align 8
+  store i16 0, ptr %local_12, align 2
+  %load_store_tmp2 = load i16, ptr %local_12, align 2
+  store i16 %load_store_tmp2, ptr %local_2, align 2
+  %load_store_tmp3 = load i256, ptr %local_11, align 8
+  store i256 %load_store_tmp3, ptr %local_3, align 8
+  br label %bb_6
+
+bb_6:                                             ; preds = %join_bb25, %bb_2
+  %load_store_tmp4 = load i16, ptr %local_2, align 2
+  store i16 %load_store_tmp4, ptr %local_13, align 2
+  store i16 256, ptr %local_14, align 2
+  %lt_src_0 = load i16, ptr %local_13, align 2
+  %lt_src_1 = load i16, ptr %local_14, align 2
+  %lt_dst = icmp ult i16 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_15, align 1
+  %cnd5 = load i1, ptr %local_15, align 1
+  br i1 %cnd5, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_6
+  br label %bb_5
+
+bb_5:                                             ; preds = %bb_4
+  %load_store_tmp6 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp6, ptr %local_16, align 8
+  %tmp7 = load ptr, ptr %local_16, align 8
+  %fld_ref8 = getelementptr inbounds %struct.bcs__BCS, ptr %tmp7, i32 0, i32 0
+  store ptr %fld_ref8, ptr %local_17__bytes, align 8
+  %loaded_alloca9 = load ptr, ptr %local_17__bytes, align 8
+  call void @move_native_vector_pop_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca9, ptr %local_18)
+  %cast_src = load i8, ptr %local_18, align 1
+  %zext_dst = zext i8 %cast_src to i256
+  store i256 %zext_dst, ptr %local_19, align 8
+  %load_store_tmp10 = load i256, ptr %local_19, align 8
+  store i256 %load_store_tmp10, ptr %local_1, align 8
+  %load_store_tmp11 = load i256, ptr %local_3, align 8
+  store i256 %load_store_tmp11, ptr %local_20, align 8
+  %load_store_tmp12 = load i256, ptr %local_1, align 8
+  store i256 %load_store_tmp12, ptr %local_21, align 8
+  %load_store_tmp13 = load i16, ptr %local_2, align 2
+  store i16 %load_store_tmp13, ptr %local_22, align 2
+  %cast_src14 = load i16, ptr %local_22, align 2
+  %castcond = icmp ugt i16 %cast_src14, 255
+  br i1 %castcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_5
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_5
+  %trunc_dst = trunc i16 %cast_src14 to i8
+  store i8 %trunc_dst, ptr %local_23, align 1
+  %shl_src_0 = load i256, ptr %local_21, align 8
+  %shl_src_1 = load i8, ptr %local_23, align 1
+  %zext_dst15 = zext i8 %shl_src_1 to i256
+  %shl_dst = shl i256 %shl_src_0, %zext_dst15
+  store i256 %shl_dst, ptr %local_24, align 8
+  %add_src_0 = load i256, ptr %local_20, align 8
+  %add_src_1 = load i256, ptr %local_24, align 8
+  %add_dst = add i256 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i256 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb16, label %join_bb17
+
+then_bb16:                                        ; preds = %join_bb
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb17:                                        ; preds = %join_bb
+  store i256 %add_dst, ptr %local_25, align 8
+  %load_store_tmp18 = load i256, ptr %local_25, align 8
+  store i256 %load_store_tmp18, ptr %local_3, align 8
+  %load_store_tmp19 = load i16, ptr %local_2, align 2
+  store i16 %load_store_tmp19, ptr %local_26, align 2
+  store i16 8, ptr %local_27, align 2
+  %add_src_020 = load i16, ptr %local_26, align 2
+  %add_src_121 = load i16, ptr %local_27, align 2
+  %add_dst22 = add i16 %add_src_020, %add_src_121
+  %ovfcond23 = icmp ult i16 %add_dst22, %add_src_020
+  br i1 %ovfcond23, label %then_bb24, label %join_bb25
+
+then_bb24:                                        ; preds = %join_bb17
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb25:                                        ; preds = %join_bb17
+  store i16 %add_dst22, ptr %local_28, align 2
+  %load_store_tmp26 = load i16, ptr %local_28, align 2
+  store i16 %load_store_tmp26, ptr %local_2, align 2
+  br label %bb_6
+
+bb_3:                                             ; preds = %bb_6
+  %load_store_tmp27 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp27, ptr %local_29, align 8
+  %load_store_tmp28 = load i256, ptr %local_3, align 8
+  store i256 %load_store_tmp28, ptr %local_30, align 8
+  %retval29 = load i256, ptr %local_30, align 8
+  ret i256 %retval29
+}
+
+define { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_addres_7uWkV96TiaFJqe"(ptr noalias nonnull %0) {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca { ptr, i64, i64 }, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca i1, align 1
+  %local_11 = alloca ptr, align 8
+  %local_12 = alloca ptr, align 8
+  %local_13 = alloca [32 x i8], align 1
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca ptr, align 8
+  %local_18 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_4, align 8
+  %call_arg_0 = load ptr, ptr %local_4, align 8
+  %retval = call i64 @"0000000000000002_bcs_peel_vec_length_HNqBjL6pYANzcQ"(ptr %call_arg_0)
+  store i64 %retval, ptr %local_5, align 8
+  store i64 0, ptr %local_6, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_address)
+  store { ptr, i64, i64 } %1, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_address, ptr %newv, ptr @vdesc)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_7, align 8
+  %load_store_tmp1 = load { ptr, i64, i64 }, ptr %local_7, align 8
+  store { ptr, i64, i64 } %load_store_tmp1, ptr %local_3, align 8
+  %load_store_tmp2 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp2, ptr %local_1, align 8
+  %load_store_tmp3 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp3, ptr %local_2, align 8
+  br label %bb_3
+
+bb_3:                                             ; preds = %join_bb, %entry
+  %load_store_tmp4 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp4, ptr %local_8, align 8
+  %load_store_tmp5 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp5, ptr %local_9, align 8
+  %lt_src_0 = load i64, ptr %local_8, align 8
+  %lt_src_1 = load i64, ptr %local_9, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_10, align 1
+  %cnd = load i1, ptr %local_10, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %bb_3
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_1
+  store ptr %local_3, ptr %local_11, align 8
+  %load_store_tmp6 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp6, ptr %local_12, align 8
+  %call_arg_07 = load ptr, ptr %local_12, align 8
+  %retval8 = call [32 x i8] @"0000000000000002_bcs_peel_address_6ieY385GfzQPhi"(ptr %call_arg_07)
+  store [32 x i8] %retval8, ptr %local_13, align 1
+  %loaded_alloca = load ptr, ptr %local_11, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_address, ptr %loaded_alloca, ptr %local_13)
+  %load_store_tmp9 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp9, ptr %local_14, align 8
+  store i64 1, ptr %local_15, align 8
+  %add_src_0 = load i64, ptr %local_14, align 8
+  %add_src_1 = load i64, ptr %local_15, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_2
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_2
+  store i64 %add_dst, ptr %local_16, align 8
+  %load_store_tmp10 = load i64, ptr %local_16, align 8
+  store i64 %load_store_tmp10, ptr %local_1, align 8
+  br label %bb_3
+
+bb_0:                                             ; preds = %bb_3
+  %load_store_tmp11 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp11, ptr %local_17, align 8
+  %load_store_tmp12 = load { ptr, i64, i64 }, ptr %local_3, align 8
+  store { ptr, i64, i64 } %load_store_tmp12, ptr %local_18, align 8
+  %retval13 = load { ptr, i64, i64 }, ptr %local_18, align 8
+  ret { ptr, i64, i64 } %retval13
+}
+
+define i64 @"0000000000000002_bcs_peel_vec_length_HNqBjL6pYANzcQ"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca i64, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca i8, align 1
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca i1, align 1
+  %local_11 = alloca ptr, align 8
+  %local_12 = alloca i64, align 8
+  %local_13 = alloca ptr, align 8
+  %local_14__bytes = alloca ptr, align 8
+  %local_15 = alloca i8, align 1
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca i64, align 8
+  %local_18 = alloca i64, align 8
+  %local_19 = alloca i64, align 8
+  %local_20 = alloca i64, align 8
+  %local_21 = alloca i64, align 8
+  %local_22 = alloca i64, align 8
+  %local_23 = alloca i64, align 8
+  %local_24 = alloca i8, align 1
+  %local_25 = alloca i64, align 8
+  %local_26 = alloca i64, align 8
+  %local_27 = alloca i64, align 8
+  %local_28 = alloca i64, align 8
+  %local_29 = alloca i64, align 8
+  %local_30 = alloca i64, align 8
+  %local_31 = alloca i1, align 1
+  %local_32 = alloca i8, align 1
+  %local_33 = alloca i8, align 1
+  %local_34 = alloca i8, align 1
+  %local_35 = alloca ptr, align 8
+  %local_36 = alloca i64, align 8
+  store ptr %0, ptr %local_0, align 8
+  store i64 0, ptr %local_5, align 8
+  store i8 0, ptr %local_6, align 1
+  store i64 0, ptr %local_7, align 8
+  %load_store_tmp = load i64, ptr %local_7, align 8
+  store i64 %load_store_tmp, ptr %local_2, align 8
+  %load_store_tmp1 = load i8, ptr %local_6, align 1
+  store i8 %load_store_tmp1, ptr %local_3, align 1
+  %load_store_tmp2 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp2, ptr %local_4, align 8
+  br label %bb_6
+
+bb_6:                                             ; preds = %join_bb27, %entry
+  %load_store_tmp3 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp3, ptr %local_8, align 8
+  store i64 4, ptr %local_9, align 8
+  %le_src_0 = load i64, ptr %local_8, align 8
+  %le_src_1 = load i64, ptr %local_9, align 8
+  %le_dst = icmp ule i64 %le_src_0, %le_src_1
+  store i1 %le_dst, ptr %local_10, align 1
+  %cnd = load i1, ptr %local_10, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %bb_6
+  br label %bb_2
+
+bb_0:                                             ; preds = %bb_6
+  %load_store_tmp4 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp4, ptr %local_11, align 8
+  store i64 2, ptr %local_12, align 8
+  %call_arg_0 = load i64, ptr %local_12, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  %load_store_tmp5 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp5, ptr %local_13, align 8
+  %tmp = load ptr, ptr %local_13, align 8
+  %fld_ref = getelementptr inbounds %struct.bcs__BCS, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_14__bytes, align 8
+  %loaded_alloca = load ptr, ptr %local_14__bytes, align 8
+  call void @move_native_vector_pop_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca, ptr %local_15)
+  %cast_src = load i8, ptr %local_15, align 1
+  %zext_dst = zext i8 %cast_src to i64
+  store i64 %zext_dst, ptr %local_16, align 8
+  %load_store_tmp6 = load i64, ptr %local_16, align 8
+  store i64 %load_store_tmp6, ptr %local_1, align 8
+  %load_store_tmp7 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp7, ptr %local_17, align 8
+  store i64 1, ptr %local_18, align 8
+  %add_src_0 = load i64, ptr %local_17, align 8
+  %add_src_1 = load i64, ptr %local_18, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_2
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_2
+  store i64 %add_dst, ptr %local_19, align 8
+  %load_store_tmp8 = load i64, ptr %local_19, align 8
+  store i64 %load_store_tmp8, ptr %local_2, align 8
+  %load_store_tmp9 = load i64, ptr %local_4, align 8
+  store i64 %load_store_tmp9, ptr %local_20, align 8
+  %load_store_tmp10 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp10, ptr %local_21, align 8
+  store i64 127, ptr %local_22, align 8
+  %and_src_0 = load i64, ptr %local_21, align 8
+  %and_src_1 = load i64, ptr %local_22, align 8
+  %and_dst = and i64 %and_src_0, %and_src_1
+  store i64 %and_dst, ptr %local_23, align 8
+  %load_store_tmp11 = load i8, ptr %local_3, align 1
+  store i8 %load_store_tmp11, ptr %local_24, align 1
+  %shl_src_0 = load i64, ptr %local_23, align 8
+  %shl_src_1 = load i8, ptr %local_24, align 1
+  %rangecond = icmp uge i8 %shl_src_1, 64
+  br i1 %rangecond, label %then_bb12, label %join_bb13
+
+then_bb12:                                        ; preds = %join_bb
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb13:                                        ; preds = %join_bb
+  %zext_dst14 = zext i8 %shl_src_1 to i64
+  %shl_dst = shl i64 %shl_src_0, %zext_dst14
+  store i64 %shl_dst, ptr %local_25, align 8
+  %or_src_0 = load i64, ptr %local_20, align 8
+  %or_src_1 = load i64, ptr %local_25, align 8
+  %or_dst = or i64 %or_src_0, %or_src_1
+  store i64 %or_dst, ptr %local_26, align 8
+  %load_store_tmp15 = load i64, ptr %local_26, align 8
+  store i64 %load_store_tmp15, ptr %local_4, align 8
+  %load_store_tmp16 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp16, ptr %local_27, align 8
+  store i64 128, ptr %local_28, align 8
+  %and_src_017 = load i64, ptr %local_27, align 8
+  %and_src_118 = load i64, ptr %local_28, align 8
+  %and_dst19 = and i64 %and_src_017, %and_src_118
+  store i64 %and_dst19, ptr %local_29, align 8
+  store i64 0, ptr %local_30, align 8
+  %eq_src_0 = load i64, ptr %local_29, align 8
+  %eq_src_1 = load i64, ptr %local_30, align 8
+  %eq_dst = icmp eq i64 %eq_src_0, %eq_src_1
+  store i1 %eq_dst, ptr %local_31, align 1
+  %cnd20 = load i1, ptr %local_31, align 1
+  br i1 %cnd20, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %join_bb13
+  br label %bb_5
+
+bb_3:                                             ; preds = %join_bb13
+  %load_store_tmp21 = load i8, ptr %local_3, align 1
+  store i8 %load_store_tmp21, ptr %local_32, align 1
+  store i8 7, ptr %local_33, align 1
+  %add_src_022 = load i8, ptr %local_32, align 1
+  %add_src_123 = load i8, ptr %local_33, align 1
+  %add_dst24 = add i8 %add_src_022, %add_src_123
+  %ovfcond25 = icmp ult i8 %add_dst24, %add_src_022
+  br i1 %ovfcond25, label %then_bb26, label %join_bb27
+
+then_bb26:                                        ; preds = %bb_3
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb27:                                        ; preds = %bb_3
+  store i8 %add_dst24, ptr %local_34, align 1
+  %load_store_tmp28 = load i8, ptr %local_34, align 1
+  store i8 %load_store_tmp28, ptr %local_3, align 1
+  br label %bb_6
+
+bb_5:                                             ; preds = %bb_4
+  %load_store_tmp29 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp29, ptr %local_35, align 8
+  %load_store_tmp30 = load i64, ptr %local_4, align 8
+  store i64 %load_store_tmp30, ptr %local_36, align 8
+  %retval = load i64, ptr %local_36, align 8
+  ret i64 %retval
+}
+
+define { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_bool_55BoGbJggFCRbo"(ptr noalias nonnull %0) {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca { ptr, i64, i64 }, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca i1, align 1
+  %local_11 = alloca ptr, align 8
+  %local_12 = alloca ptr, align 8
+  %local_13 = alloca i1, align 1
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca ptr, align 8
+  %local_18 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_4, align 8
+  %call_arg_0 = load ptr, ptr %local_4, align 8
+  %retval = call i64 @"0000000000000002_bcs_peel_vec_length_HNqBjL6pYANzcQ"(ptr %call_arg_0)
+  store i64 %retval, ptr %local_5, align 8
+  store i64 0, ptr %local_6, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_bool)
+  store { ptr, i64, i64 } %1, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_bool, ptr %newv, ptr @vdesc.2)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_7, align 8
+  %load_store_tmp1 = load { ptr, i64, i64 }, ptr %local_7, align 8
+  store { ptr, i64, i64 } %load_store_tmp1, ptr %local_3, align 8
+  %load_store_tmp2 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp2, ptr %local_1, align 8
+  %load_store_tmp3 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp3, ptr %local_2, align 8
+  br label %bb_3
+
+bb_3:                                             ; preds = %join_bb, %entry
+  %load_store_tmp4 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp4, ptr %local_8, align 8
+  %load_store_tmp5 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp5, ptr %local_9, align 8
+  %lt_src_0 = load i64, ptr %local_8, align 8
+  %lt_src_1 = load i64, ptr %local_9, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_10, align 1
+  %cnd = load i1, ptr %local_10, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %bb_3
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_1
+  store ptr %local_3, ptr %local_11, align 8
+  %load_store_tmp6 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp6, ptr %local_12, align 8
+  %call_arg_07 = load ptr, ptr %local_12, align 8
+  %retval8 = call i1 @"0000000000000002_bcs_peel_bool_3uzNfP9g7KxJxU"(ptr %call_arg_07)
+  store i1 %retval8, ptr %local_13, align 1
+  %loaded_alloca = load ptr, ptr %local_11, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_bool, ptr %loaded_alloca, ptr %local_13)
+  %load_store_tmp9 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp9, ptr %local_14, align 8
+  store i64 1, ptr %local_15, align 8
+  %add_src_0 = load i64, ptr %local_14, align 8
+  %add_src_1 = load i64, ptr %local_15, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_2
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_2
+  store i64 %add_dst, ptr %local_16, align 8
+  %load_store_tmp10 = load i64, ptr %local_16, align 8
+  store i64 %load_store_tmp10, ptr %local_1, align 8
+  br label %bb_3
+
+bb_0:                                             ; preds = %bb_3
+  %load_store_tmp11 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp11, ptr %local_17, align 8
+  %load_store_tmp12 = load { ptr, i64, i64 }, ptr %local_3, align 8
+  store { ptr, i64, i64 } %load_store_tmp12, ptr %local_18, align 8
+  %retval13 = load { ptr, i64, i64 }, ptr %local_18, align 8
+  ret { ptr, i64, i64 } %retval13
+}
+
+define { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_u128_FkuW25NBimnBdr"(ptr noalias nonnull %0) {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca { ptr, i64, i64 }, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca i1, align 1
+  %local_11 = alloca ptr, align 8
+  %local_12 = alloca ptr, align 8
+  %local_13 = alloca i128, align 8
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca ptr, align 8
+  %local_18 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_4, align 8
+  %call_arg_0 = load ptr, ptr %local_4, align 8
+  %retval = call i64 @"0000000000000002_bcs_peel_vec_length_HNqBjL6pYANzcQ"(ptr %call_arg_0)
+  store i64 %retval, ptr %local_5, align 8
+  store i64 0, ptr %local_6, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u128)
+  store { ptr, i64, i64 } %1, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u128, ptr %newv, ptr @vdesc.4)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_7, align 8
+  %load_store_tmp1 = load { ptr, i64, i64 }, ptr %local_7, align 8
+  store { ptr, i64, i64 } %load_store_tmp1, ptr %local_3, align 8
+  %load_store_tmp2 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp2, ptr %local_1, align 8
+  %load_store_tmp3 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp3, ptr %local_2, align 8
+  br label %bb_3
+
+bb_3:                                             ; preds = %join_bb, %entry
+  %load_store_tmp4 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp4, ptr %local_8, align 8
+  %load_store_tmp5 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp5, ptr %local_9, align 8
+  %lt_src_0 = load i64, ptr %local_8, align 8
+  %lt_src_1 = load i64, ptr %local_9, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_10, align 1
+  %cnd = load i1, ptr %local_10, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %bb_3
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_1
+  store ptr %local_3, ptr %local_11, align 8
+  %load_store_tmp6 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp6, ptr %local_12, align 8
+  %call_arg_07 = load ptr, ptr %local_12, align 8
+  %retval8 = call i128 @"0000000000000002_bcs_peel_u128_NmHT5JzgtEzTCJ"(ptr %call_arg_07)
+  store i128 %retval8, ptr %local_13, align 8
+  %loaded_alloca = load ptr, ptr %local_11, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u128, ptr %loaded_alloca, ptr %local_13)
+  %load_store_tmp9 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp9, ptr %local_14, align 8
+  store i64 1, ptr %local_15, align 8
+  %add_src_0 = load i64, ptr %local_14, align 8
+  %add_src_1 = load i64, ptr %local_15, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_2
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_2
+  store i64 %add_dst, ptr %local_16, align 8
+  %load_store_tmp10 = load i64, ptr %local_16, align 8
+  store i64 %load_store_tmp10, ptr %local_1, align 8
+  br label %bb_3
+
+bb_0:                                             ; preds = %bb_3
+  %load_store_tmp11 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp11, ptr %local_17, align 8
+  %load_store_tmp12 = load { ptr, i64, i64 }, ptr %local_3, align 8
+  store { ptr, i64, i64 } %load_store_tmp12, ptr %local_18, align 8
+  %retval13 = load { ptr, i64, i64 }, ptr %local_18, align 8
+  ret { ptr, i64, i64 } %retval13
+}
+
+define { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_u64_DNtE2HaiuV6VEn"(ptr noalias nonnull %0) {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca { ptr, i64, i64 }, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca i1, align 1
+  %local_11 = alloca ptr, align 8
+  %local_12 = alloca ptr, align 8
+  %local_13 = alloca i64, align 8
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca ptr, align 8
+  %local_18 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_4, align 8
+  %call_arg_0 = load ptr, ptr %local_4, align 8
+  %retval = call i64 @"0000000000000002_bcs_peel_vec_length_HNqBjL6pYANzcQ"(ptr %call_arg_0)
+  store i64 %retval, ptr %local_5, align 8
+  store i64 0, ptr %local_6, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u64)
+  store { ptr, i64, i64 } %1, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u64, ptr %newv, ptr @vdesc.6)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_7, align 8
+  %load_store_tmp1 = load { ptr, i64, i64 }, ptr %local_7, align 8
+  store { ptr, i64, i64 } %load_store_tmp1, ptr %local_3, align 8
+  %load_store_tmp2 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp2, ptr %local_1, align 8
+  %load_store_tmp3 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp3, ptr %local_2, align 8
+  br label %bb_3
+
+bb_3:                                             ; preds = %join_bb, %entry
+  %load_store_tmp4 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp4, ptr %local_8, align 8
+  %load_store_tmp5 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp5, ptr %local_9, align 8
+  %lt_src_0 = load i64, ptr %local_8, align 8
+  %lt_src_1 = load i64, ptr %local_9, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_10, align 1
+  %cnd = load i1, ptr %local_10, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %bb_3
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_1
+  store ptr %local_3, ptr %local_11, align 8
+  %load_store_tmp6 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp6, ptr %local_12, align 8
+  %call_arg_07 = load ptr, ptr %local_12, align 8
+  %retval8 = call i64 @"0000000000000002_bcs_peel_u64_AL793VCQ2sZbgn"(ptr %call_arg_07)
+  store i64 %retval8, ptr %local_13, align 8
+  %loaded_alloca = load ptr, ptr %local_11, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u64, ptr %loaded_alloca, ptr %local_13)
+  %load_store_tmp9 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp9, ptr %local_14, align 8
+  store i64 1, ptr %local_15, align 8
+  %add_src_0 = load i64, ptr %local_14, align 8
+  %add_src_1 = load i64, ptr %local_15, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_2
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_2
+  store i64 %add_dst, ptr %local_16, align 8
+  %load_store_tmp10 = load i64, ptr %local_16, align 8
+  store i64 %load_store_tmp10, ptr %local_1, align 8
+  br label %bb_3
+
+bb_0:                                             ; preds = %bb_3
+  %load_store_tmp11 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp11, ptr %local_17, align 8
+  %load_store_tmp12 = load { ptr, i64, i64 }, ptr %local_3, align 8
+  store { ptr, i64, i64 } %load_store_tmp12, ptr %local_18, align 8
+  %retval13 = load { ptr, i64, i64 }, ptr %local_18, align 8
+  ret { ptr, i64, i64 } %retval13
+}
+
+define { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_u8_4z7Az3QuZfeaFB"(ptr noalias nonnull %0) {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca { ptr, i64, i64 }, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca i1, align 1
+  %local_11 = alloca ptr, align 8
+  %local_12 = alloca ptr, align 8
+  %local_13 = alloca i8, align 1
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca ptr, align 8
+  %local_18 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_4, align 8
+  %call_arg_0 = load ptr, ptr %local_4, align 8
+  %retval = call i64 @"0000000000000002_bcs_peel_vec_length_HNqBjL6pYANzcQ"(ptr %call_arg_0)
+  store i64 %retval, ptr %local_5, align 8
+  store i64 0, ptr %local_6, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %1, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.8)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_7, align 8
+  %load_store_tmp1 = load { ptr, i64, i64 }, ptr %local_7, align 8
+  store { ptr, i64, i64 } %load_store_tmp1, ptr %local_3, align 8
+  %load_store_tmp2 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp2, ptr %local_1, align 8
+  %load_store_tmp3 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp3, ptr %local_2, align 8
+  br label %bb_3
+
+bb_3:                                             ; preds = %join_bb, %entry
+  %load_store_tmp4 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp4, ptr %local_8, align 8
+  %load_store_tmp5 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp5, ptr %local_9, align 8
+  %lt_src_0 = load i64, ptr %local_8, align 8
+  %lt_src_1 = load i64, ptr %local_9, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_10, align 1
+  %cnd = load i1, ptr %local_10, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %bb_3
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_1
+  store ptr %local_3, ptr %local_11, align 8
+  %load_store_tmp6 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp6, ptr %local_12, align 8
+  %call_arg_07 = load ptr, ptr %local_12, align 8
+  %retval8 = call i8 @"0000000000000002_bcs_peel_u8_6d6AGS42yhTNFk"(ptr %call_arg_07)
+  store i8 %retval8, ptr %local_13, align 1
+  %loaded_alloca = load ptr, ptr %local_11, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca, ptr %local_13)
+  %load_store_tmp9 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp9, ptr %local_14, align 8
+  store i64 1, ptr %local_15, align 8
+  %add_src_0 = load i64, ptr %local_14, align 8
+  %add_src_1 = load i64, ptr %local_15, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_2
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_2
+  store i64 %add_dst, ptr %local_16, align 8
+  %load_store_tmp10 = load i64, ptr %local_16, align 8
+  store i64 %load_store_tmp10, ptr %local_1, align 8
+  br label %bb_3
+
+bb_0:                                             ; preds = %bb_3
+  %load_store_tmp11 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp11, ptr %local_17, align 8
+  %load_store_tmp12 = load { ptr, i64, i64 }, ptr %local_3, align 8
+  store { ptr, i64, i64 } %load_store_tmp12, ptr %local_18, align 8
+  %retval13 = load { ptr, i64, i64 }, ptr %local_18, align 8
+  ret { ptr, i64, i64 } %retval13
+}
+
+define { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_vec_u8_7PcPmN6rdUgmA9"(ptr noalias nonnull %0) {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca { ptr, i64, i64 }, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca i1, align 1
+  %local_11 = alloca ptr, align 8
+  %local_12 = alloca ptr, align 8
+  %local_13 = alloca { ptr, i64, i64 }, align 8
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca ptr, align 8
+  %local_18 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_4, align 8
+  %call_arg_0 = load ptr, ptr %local_4, align 8
+  %retval = call i64 @"0000000000000002_bcs_peel_vec_length_HNqBjL6pYANzcQ"(ptr %call_arg_0)
+  store i64 %retval, ptr %local_5, align 8
+  store i64 0, ptr %local_6, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %1, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.10)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_7, align 8
+  %load_store_tmp1 = load { ptr, i64, i64 }, ptr %local_7, align 8
+  store { ptr, i64, i64 } %load_store_tmp1, ptr %local_3, align 8
+  %load_store_tmp2 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp2, ptr %local_1, align 8
+  %load_store_tmp3 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp3, ptr %local_2, align 8
+  br label %bb_3
+
+bb_3:                                             ; preds = %join_bb, %entry
+  %load_store_tmp4 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp4, ptr %local_8, align 8
+  %load_store_tmp5 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp5, ptr %local_9, align 8
+  %lt_src_0 = load i64, ptr %local_8, align 8
+  %lt_src_1 = load i64, ptr %local_9, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_10, align 1
+  %cnd = load i1, ptr %local_10, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %bb_3
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_1
+  store ptr %local_3, ptr %local_11, align 8
+  %load_store_tmp6 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp6, ptr %local_12, align 8
+  %call_arg_07 = load ptr, ptr %local_12, align 8
+  %retval8 = call { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_u8_4z7Az3QuZfeaFB"(ptr %call_arg_07)
+  store { ptr, i64, i64 } %retval8, ptr %local_13, align 8
+  %loaded_alloca = load ptr, ptr %local_11, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_vector_u8_, ptr %loaded_alloca, ptr %local_13)
+  %load_store_tmp9 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp9, ptr %local_14, align 8
+  store i64 1, ptr %local_15, align 8
+  %add_src_0 = load i64, ptr %local_14, align 8
+  %add_src_1 = load i64, ptr %local_15, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_2
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_2
+  store i64 %add_dst, ptr %local_16, align 8
+  %load_store_tmp10 = load i64, ptr %local_16, align 8
+  store i64 %load_store_tmp10, ptr %local_1, align 8
+  br label %bb_3
+
+bb_0:                                             ; preds = %bb_3
+  %load_store_tmp11 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp11, ptr %local_17, align 8
+  %load_store_tmp12 = load { ptr, i64, i64 }, ptr %local_3, align 8
+  store { ptr, i64, i64 } %load_store_tmp12, ptr %local_18, align 8
+  %retval13 = load { ptr, i64, i64 }, ptr %local_18, align 8
+  ret { ptr, i64, i64 } %retval13
+}
+
+define private void @"0000000000000002_bcs_test_bcs_AuukBNfz84sy81"() {
+entry:
+  %newv279 = alloca { ptr, i64, i64 }, align 8
+  %newv266 = alloca { ptr, i64, i64 }, align 8
+  %newv253 = alloca { ptr, i64, i64 }, align 8
+  %newv240 = alloca { ptr, i64, i64 }, align 8
+  %newv227 = alloca { ptr, i64, i64 }, align 8
+  %newv214 = alloca { ptr, i64, i64 }, align 8
+  %newv120 = alloca { ptr, i64, i64 }, align 8
+  %newv103 = alloca { ptr, i64, i64 }, align 8
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca %struct.bcs__BCS, align 8
+  %local_1 = alloca %struct.bcs__BCS, align 8
+  %local_2 = alloca %struct.bcs__BCS, align 8
+  %local_3 = alloca %struct.bcs__BCS, align 8
+  %local_4 = alloca %struct.bcs__BCS, align 8
+  %local_5 = alloca %struct.bcs__BCS, align 8
+  %local_6 = alloca %struct.bcs__BCS, align 8
+  %local_7 = alloca %struct.bcs__BCS, align 8
+  %local_8 = alloca %struct.bcs__BCS, align 8
+  %local_9 = alloca %struct.bcs__BCS, align 8
+  %local_10 = alloca %struct.bcs__BCS, align 8
+  %local_11 = alloca %struct.bcs__BCS, align 8
+  %local_12 = alloca %struct.bcs__BCS, align 8
+  %local_13 = alloca %struct.bcs__BCS, align 8
+  %local_14 = alloca %struct.bcs__BCS, align 8
+  %local_15 = alloca %struct.bcs__BCS, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca %struct.bcs__Info, align 8
+  %local_18 = alloca i64, align 8
+  %local_19 = alloca [32 x i8], align 1
+  %local_20 = alloca { ptr, i64, i64 }, align 8
+  %local_21 = alloca { ptr, i64, i64 }, align 8
+  %local_22 = alloca { ptr, i64, i64 }, align 8
+  %local_23 = alloca { ptr, i64, i64 }, align 8
+  %local_24 = alloca { ptr, i64, i64 }, align 8
+  %local_25 = alloca { ptr, i64, i64 }, align 8
+  %local_26 = alloca i1, align 1
+  %local_27 = alloca i1, align 1
+  %local_28 = alloca i8, align 1
+  %local_29 = alloca i64, align 8
+  %local_30 = alloca i64, align 8
+  %local_31 = alloca i128, align 8
+  %local_32 = alloca { ptr, i64, i64 }, align 8
+  %local_33 = alloca { ptr, i64, i64 }, align 8
+  %local_34 = alloca [32 x i8], align 1
+  %local_35 = alloca ptr, align 8
+  %local_36 = alloca { ptr, i64, i64 }, align 8
+  %local_37 = alloca %struct.bcs__BCS, align 8
+  %local_38 = alloca [32 x i8], align 1
+  %local_39 = alloca ptr, align 8
+  %local_40 = alloca [32 x i8], align 1
+  %local_41 = alloca i1, align 1
+  %local_42 = alloca i64, align 8
+  %local_43 = alloca i1, align 1
+  %local_44 = alloca ptr, align 8
+  %local_45 = alloca { ptr, i64, i64 }, align 8
+  %local_46 = alloca %struct.bcs__BCS, align 8
+  %local_47 = alloca i1, align 1
+  %local_48 = alloca ptr, align 8
+  %local_49 = alloca i1, align 1
+  %local_50 = alloca i1, align 1
+  %local_51 = alloca i64, align 8
+  %local_52 = alloca i1, align 1
+  %local_53 = alloca ptr, align 8
+  %local_54 = alloca { ptr, i64, i64 }, align 8
+  %local_55 = alloca %struct.bcs__BCS, align 8
+  %local_56 = alloca i1, align 1
+  %local_57 = alloca ptr, align 8
+  %local_58 = alloca i1, align 1
+  %local_59 = alloca i1, align 1
+  %local_60 = alloca i64, align 8
+  %local_61 = alloca i8, align 1
+  %local_62 = alloca ptr, align 8
+  %local_63 = alloca { ptr, i64, i64 }, align 8
+  %local_64 = alloca %struct.bcs__BCS, align 8
+  %local_65 = alloca i8, align 1
+  %local_66 = alloca ptr, align 8
+  %local_67 = alloca i8, align 1
+  %local_68 = alloca i1, align 1
+  %local_69 = alloca i64, align 8
+  %local_70 = alloca i64, align 8
+  %local_71 = alloca ptr, align 8
+  %local_72 = alloca { ptr, i64, i64 }, align 8
+  %local_73 = alloca %struct.bcs__BCS, align 8
+  %local_74 = alloca i64, align 8
+  %local_75 = alloca ptr, align 8
+  %local_76 = alloca i64, align 8
+  %local_77 = alloca i1, align 1
+  %local_78 = alloca i64, align 8
+  %local_79 = alloca i64, align 8
+  %local_80 = alloca ptr, align 8
+  %local_81 = alloca { ptr, i64, i64 }, align 8
+  %local_82 = alloca %struct.bcs__BCS, align 8
+  %local_83 = alloca i64, align 8
+  %local_84 = alloca ptr, align 8
+  %local_85 = alloca i64, align 8
+  %local_86 = alloca i1, align 1
+  %local_87 = alloca i64, align 8
+  %local_88 = alloca i128, align 8
+  %local_89 = alloca ptr, align 8
+  %local_90 = alloca { ptr, i64, i64 }, align 8
+  %local_91 = alloca %struct.bcs__BCS, align 8
+  %local_92 = alloca i128, align 8
+  %local_93 = alloca ptr, align 8
+  %local_94 = alloca i128, align 8
+  %local_95 = alloca i1, align 1
+  %local_96 = alloca i64, align 8
+  %local_97 = alloca { ptr, i64, i64 }, align 8
+  %local_98 = alloca ptr, align 8
+  %local_99 = alloca { ptr, i64, i64 }, align 8
+  %local_100 = alloca %struct.bcs__BCS, align 8
+  %local_101 = alloca ptr, align 8
+  %local_102 = alloca i64, align 8
+  %local_103 = alloca ptr, align 8
+  %local_104 = alloca i64, align 8
+  %local_105 = alloca i1, align 1
+  %local_106 = alloca i64, align 8
+  %local_107 = alloca { ptr, i64, i64 }, align 8
+  %local_108 = alloca ptr, align 8
+  %local_109 = alloca { ptr, i64, i64 }, align 8
+  %local_110 = alloca %struct.bcs__BCS, align 8
+  %local_111 = alloca ptr, align 8
+  %local_112 = alloca i64, align 8
+  %local_113 = alloca ptr, align 8
+  %local_114 = alloca i64, align 8
+  %local_115 = alloca i1, align 1
+  %local_116 = alloca i64, align 8
+  %local_117__a = alloca i1, align 1
+  %local_118__b = alloca i8, align 1
+  %local_119__c = alloca i64, align 8
+  %local_120__d = alloca i128, align 8
+  %local_121__k = alloca { ptr, i64, i64 }, align 8
+  %local_122__s = alloca [32 x i8], align 1
+  %local_123 = alloca %struct.bcs__Info, align 8
+  %local_124 = alloca ptr, align 8
+  %local_125 = alloca { ptr, i64, i64 }, align 8
+  %local_126 = alloca %struct.bcs__BCS, align 8
+  %local_127 = alloca ptr, align 8
+  %local_128__a = alloca ptr, align 8
+  %local_129 = alloca i1, align 1
+  %local_130 = alloca ptr, align 8
+  %local_131 = alloca i1, align 1
+  %local_132 = alloca i1, align 1
+  %local_133 = alloca i64, align 8
+  %local_134 = alloca ptr, align 8
+  %local_135__b = alloca ptr, align 8
+  %local_136 = alloca i8, align 1
+  %local_137 = alloca ptr, align 8
+  %local_138 = alloca i8, align 1
+  %local_139 = alloca i1, align 1
+  %local_140 = alloca i64, align 8
+  %local_141 = alloca ptr, align 8
+  %local_142__c = alloca ptr, align 8
+  %local_143 = alloca i64, align 8
+  %local_144 = alloca ptr, align 8
+  %local_145 = alloca i64, align 8
+  %local_146 = alloca i1, align 1
+  %local_147 = alloca i64, align 8
+  %local_148 = alloca ptr, align 8
+  %local_149__d = alloca ptr, align 8
+  %local_150 = alloca i128, align 8
+  %local_151 = alloca ptr, align 8
+  %local_152 = alloca i128, align 8
+  %local_153 = alloca i1, align 1
+  %local_154 = alloca i64, align 8
+  %local_155 = alloca ptr, align 8
+  %local_156 = alloca i64, align 8
+  %local_157 = alloca ptr, align 8
+  %local_158__k = alloca ptr, align 8
+  %local_159 = alloca i64, align 8
+  %local_160 = alloca i64, align 8
+  %local_161 = alloca i1, align 1
+  %local_162 = alloca i64, align 8
+  %local_163 = alloca i64, align 8
+  %local_164 = alloca i64, align 8
+  %local_165 = alloca ptr, align 8
+  %local_166__k = alloca ptr, align 8
+  %local_167 = alloca i64, align 8
+  %local_168 = alloca i1, align 1
+  %local_169 = alloca ptr, align 8
+  %local_170__k = alloca ptr, align 8
+  %local_171 = alloca i64, align 8
+  %local_172 = alloca ptr, align 8
+  %local_173 = alloca i1, align 1
+  %local_174 = alloca ptr, align 8
+  %local_175 = alloca i1, align 1
+  %local_176 = alloca i1, align 1
+  %local_177 = alloca i64, align 8
+  %local_178 = alloca i64, align 8
+  %local_179 = alloca i64, align 8
+  %local_180 = alloca i64, align 8
+  %local_181 = alloca ptr, align 8
+  %local_182__s = alloca ptr, align 8
+  %local_183 = alloca [32 x i8], align 1
+  %local_184 = alloca ptr, align 8
+  %local_185 = alloca [32 x i8], align 1
+  %local_186 = alloca i1, align 1
+  %local_187 = alloca i64, align 8
+  %local_188 = alloca { ptr, i64, i64 }, align 8
+  %local_189 = alloca ptr, align 8
+  %local_190 = alloca { ptr, i64, i64 }, align 8
+  %local_191 = alloca %struct.bcs__BCS, align 8
+  %local_192 = alloca { ptr, i64, i64 }, align 8
+  %local_193 = alloca ptr, align 8
+  %local_194 = alloca { ptr, i64, i64 }, align 8
+  %local_195 = alloca i1, align 1
+  %local_196 = alloca i64, align 8
+  %local_197 = alloca { ptr, i64, i64 }, align 8
+  %local_198 = alloca ptr, align 8
+  %local_199 = alloca { ptr, i64, i64 }, align 8
+  %local_200 = alloca %struct.bcs__BCS, align 8
+  %local_201 = alloca { ptr, i64, i64 }, align 8
+  %local_202 = alloca ptr, align 8
+  %local_203 = alloca { ptr, i64, i64 }, align 8
+  %local_204 = alloca i1, align 1
+  %local_205 = alloca i64, align 8
+  %local_206 = alloca { ptr, i64, i64 }, align 8
+  %local_207 = alloca ptr, align 8
+  %local_208 = alloca { ptr, i64, i64 }, align 8
+  %local_209 = alloca %struct.bcs__BCS, align 8
+  %local_210 = alloca { ptr, i64, i64 }, align 8
+  %local_211 = alloca ptr, align 8
+  %local_212 = alloca { ptr, i64, i64 }, align 8
+  %local_213 = alloca i1, align 1
+  %local_214 = alloca i64, align 8
+  %local_215 = alloca { ptr, i64, i64 }, align 8
+  %local_216 = alloca ptr, align 8
+  %local_217 = alloca { ptr, i64, i64 }, align 8
+  %local_218 = alloca %struct.bcs__BCS, align 8
+  %local_219 = alloca { ptr, i64, i64 }, align 8
+  %local_220 = alloca ptr, align 8
+  %local_221 = alloca { ptr, i64, i64 }, align 8
+  %local_222 = alloca i1, align 1
+  %local_223 = alloca i64, align 8
+  %local_224 = alloca { ptr, i64, i64 }, align 8
+  %local_225 = alloca ptr, align 8
+  %local_226 = alloca { ptr, i64, i64 }, align 8
+  %local_227 = alloca %struct.bcs__BCS, align 8
+  %local_228 = alloca { ptr, i64, i64 }, align 8
+  %local_229 = alloca ptr, align 8
+  %local_230 = alloca { ptr, i64, i64 }, align 8
+  %local_231 = alloca i1, align 1
+  %local_232 = alloca i64, align 8
+  %local_233 = alloca { ptr, i64, i64 }, align 8
+  %local_234 = alloca ptr, align 8
+  %local_235 = alloca { ptr, i64, i64 }, align 8
+  %local_236 = alloca %struct.bcs__BCS, align 8
+  %local_237 = alloca { ptr, i64, i64 }, align 8
+  %local_238 = alloca ptr, align 8
+  %local_239 = alloca { ptr, i64, i64 }, align 8
+  %local_240 = alloca i1, align 1
+  %local_241 = alloca i64, align 8
+  %0 = load [32 x i8], ptr @acct.addr, align 1
+  store [32 x i8] %0, ptr %local_34, align 1
+  %load_store_tmp = load [32 x i8], ptr %local_34, align 1
+  store [32 x i8] %load_store_tmp, ptr %local_19, align 1
+  store ptr %local_19, ptr %local_35, align 8
+  %call_arg_0 = load ptr, ptr %local_35, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_6z6DhCEHM2cfNu"(ptr %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_36, align 8
+  %call_arg_01 = load { ptr, i64, i64 }, ptr %local_36, align 8
+  %retval2 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_01)
+  store %struct.bcs__BCS %retval2, ptr %local_37, align 8
+  %load_store_tmp3 = load %struct.bcs__BCS, ptr %local_37, align 8
+  store %struct.bcs__BCS %load_store_tmp3, ptr %local_0, align 8
+  store ptr %local_0, ptr %local_39, align 8
+  %call_arg_04 = load ptr, ptr %local_39, align 8
+  %retval5 = call [32 x i8] @"0000000000000002_bcs_peel_address_6ieY385GfzQPhi"(ptr %call_arg_04)
+  store [32 x i8] %retval5, ptr %local_40, align 1
+  %1 = call i32 @memcmp(ptr %local_19, ptr %local_40, i64 32)
+  %eq_dst = icmp eq i32 %1, 0
+  store i1 %eq_dst, ptr %local_41, align 1
+  %cnd = load i1, ptr %local_41, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i64 0, ptr %local_42, align 8
+  %call_arg_06 = load i64, ptr %local_42, align 8
+  call void @move_rt_abort(i64 %call_arg_06)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  store i1 true, ptr %local_43, align 1
+  %load_store_tmp7 = load i1, ptr %local_43, align 1
+  store i1 %load_store_tmp7, ptr %local_26, align 1
+  store ptr %local_26, ptr %local_44, align 8
+  %call_arg_08 = load ptr, ptr %local_44, align 8
+  %retval9 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_4uemf4C6AKb21F"(ptr %call_arg_08)
+  store { ptr, i64, i64 } %retval9, ptr %local_45, align 8
+  %call_arg_010 = load { ptr, i64, i64 }, ptr %local_45, align 8
+  %retval11 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_010)
+  store %struct.bcs__BCS %retval11, ptr %local_46, align 8
+  %load_store_tmp12 = load %struct.bcs__BCS, ptr %local_46, align 8
+  store %struct.bcs__BCS %load_store_tmp12, ptr %local_8, align 8
+  %load_store_tmp13 = load i1, ptr %local_26, align 1
+  store i1 %load_store_tmp13, ptr %local_47, align 1
+  store ptr %local_8, ptr %local_48, align 8
+  %call_arg_014 = load ptr, ptr %local_48, align 8
+  %retval15 = call i1 @"0000000000000002_bcs_peel_bool_3uzNfP9g7KxJxU"(ptr %call_arg_014)
+  store i1 %retval15, ptr %local_49, align 1
+  %eq_src_0 = load i1, ptr %local_47, align 1
+  %eq_src_1 = load i1, ptr %local_49, align 1
+  %eq_dst16 = icmp eq i1 %eq_src_0, %eq_src_1
+  store i1 %eq_dst16, ptr %local_50, align 1
+  %cnd17 = load i1, ptr %local_50, align 1
+  br i1 %cnd17, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  store i64 0, ptr %local_51, align 8
+  %call_arg_018 = load i64, ptr %local_51, align 8
+  call void @move_rt_abort(i64 %call_arg_018)
+  unreachable
+
+bb_5:                                             ; preds = %bb_4
+  store i1 false, ptr %local_52, align 1
+  %load_store_tmp19 = load i1, ptr %local_52, align 1
+  store i1 %load_store_tmp19, ptr %local_27, align 1
+  store ptr %local_27, ptr %local_53, align 8
+  %call_arg_020 = load ptr, ptr %local_53, align 8
+  %retval21 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_4uemf4C6AKb21F"(ptr %call_arg_020)
+  store { ptr, i64, i64 } %retval21, ptr %local_54, align 8
+  %call_arg_022 = load { ptr, i64, i64 }, ptr %local_54, align 8
+  %retval23 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_022)
+  store %struct.bcs__BCS %retval23, ptr %local_55, align 8
+  %load_store_tmp24 = load %struct.bcs__BCS, ptr %local_55, align 8
+  store %struct.bcs__BCS %load_store_tmp24, ptr %local_9, align 8
+  %load_store_tmp25 = load i1, ptr %local_27, align 1
+  store i1 %load_store_tmp25, ptr %local_56, align 1
+  store ptr %local_9, ptr %local_57, align 8
+  %call_arg_026 = load ptr, ptr %local_57, align 8
+  %retval27 = call i1 @"0000000000000002_bcs_peel_bool_3uzNfP9g7KxJxU"(ptr %call_arg_026)
+  store i1 %retval27, ptr %local_58, align 1
+  %eq_src_028 = load i1, ptr %local_56, align 1
+  %eq_src_129 = load i1, ptr %local_58, align 1
+  %eq_dst30 = icmp eq i1 %eq_src_028, %eq_src_129
+  store i1 %eq_dst30, ptr %local_59, align 1
+  %cnd31 = load i1, ptr %local_59, align 1
+  br i1 %cnd31, label %bb_7, label %bb_6
+
+bb_7:                                             ; preds = %bb_5
+  br label %bb_8
+
+bb_6:                                             ; preds = %bb_5
+  store i64 0, ptr %local_60, align 8
+  %call_arg_032 = load i64, ptr %local_60, align 8
+  call void @move_rt_abort(i64 %call_arg_032)
+  unreachable
+
+bb_8:                                             ; preds = %bb_7
+  store i8 100, ptr %local_61, align 1
+  %load_store_tmp33 = load i8, ptr %local_61, align 1
+  store i8 %load_store_tmp33, ptr %local_28, align 1
+  store ptr %local_28, ptr %local_62, align 8
+  %call_arg_034 = load ptr, ptr %local_62, align 8
+  %retval35 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_27yEv5Fct1GqPE"(ptr %call_arg_034)
+  store { ptr, i64, i64 } %retval35, ptr %local_63, align 8
+  %call_arg_036 = load { ptr, i64, i64 }, ptr %local_63, align 8
+  %retval37 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_036)
+  store %struct.bcs__BCS %retval37, ptr %local_64, align 8
+  %load_store_tmp38 = load %struct.bcs__BCS, ptr %local_64, align 8
+  store %struct.bcs__BCS %load_store_tmp38, ptr %local_10, align 8
+  %load_store_tmp39 = load i8, ptr %local_28, align 1
+  store i8 %load_store_tmp39, ptr %local_65, align 1
+  store ptr %local_10, ptr %local_66, align 8
+  %call_arg_040 = load ptr, ptr %local_66, align 8
+  %retval41 = call i8 @"0000000000000002_bcs_peel_u8_6d6AGS42yhTNFk"(ptr %call_arg_040)
+  store i8 %retval41, ptr %local_67, align 1
+  %eq_src_042 = load i8, ptr %local_65, align 1
+  %eq_src_143 = load i8, ptr %local_67, align 1
+  %eq_dst44 = icmp eq i8 %eq_src_042, %eq_src_143
+  store i1 %eq_dst44, ptr %local_68, align 1
+  %cnd45 = load i1, ptr %local_68, align 1
+  br i1 %cnd45, label %bb_10, label %bb_9
+
+bb_10:                                            ; preds = %bb_8
+  br label %bb_11
+
+bb_9:                                             ; preds = %bb_8
+  store i64 0, ptr %local_69, align 8
+  %call_arg_046 = load i64, ptr %local_69, align 8
+  call void @move_rt_abort(i64 %call_arg_046)
+  unreachable
+
+bb_11:                                            ; preds = %bb_10
+  store i64 1000100, ptr %local_70, align 8
+  %load_store_tmp47 = load i64, ptr %local_70, align 8
+  store i64 %load_store_tmp47, ptr %local_29, align 8
+  store ptr %local_29, ptr %local_71, align 8
+  %call_arg_048 = load ptr, ptr %local_71, align 8
+  %retval49 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_6NhXVWFo2aWmc9"(ptr %call_arg_048)
+  store { ptr, i64, i64 } %retval49, ptr %local_72, align 8
+  %call_arg_050 = load { ptr, i64, i64 }, ptr %local_72, align 8
+  %retval51 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_050)
+  store %struct.bcs__BCS %retval51, ptr %local_73, align 8
+  %load_store_tmp52 = load %struct.bcs__BCS, ptr %local_73, align 8
+  store %struct.bcs__BCS %load_store_tmp52, ptr %local_11, align 8
+  %load_store_tmp53 = load i64, ptr %local_29, align 8
+  store i64 %load_store_tmp53, ptr %local_74, align 8
+  store ptr %local_11, ptr %local_75, align 8
+  %call_arg_054 = load ptr, ptr %local_75, align 8
+  %retval55 = call i64 @"0000000000000002_bcs_peel_u64_AL793VCQ2sZbgn"(ptr %call_arg_054)
+  store i64 %retval55, ptr %local_76, align 8
+  %eq_src_056 = load i64, ptr %local_74, align 8
+  %eq_src_157 = load i64, ptr %local_76, align 8
+  %eq_dst58 = icmp eq i64 %eq_src_056, %eq_src_157
+  store i1 %eq_dst58, ptr %local_77, align 1
+  %cnd59 = load i1, ptr %local_77, align 1
+  br i1 %cnd59, label %bb_13, label %bb_12
+
+bb_13:                                            ; preds = %bb_11
+  br label %bb_14
+
+bb_12:                                            ; preds = %bb_11
+  store i64 0, ptr %local_78, align 8
+  %call_arg_060 = load i64, ptr %local_78, align 8
+  call void @move_rt_abort(i64 %call_arg_060)
+  unreachable
+
+bb_14:                                            ; preds = %bb_13
+  store i64 100000000000000, ptr %local_79, align 8
+  %load_store_tmp61 = load i64, ptr %local_79, align 8
+  store i64 %load_store_tmp61, ptr %local_30, align 8
+  store ptr %local_30, ptr %local_80, align 8
+  %call_arg_062 = load ptr, ptr %local_80, align 8
+  %retval63 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_6NhXVWFo2aWmc9"(ptr %call_arg_062)
+  store { ptr, i64, i64 } %retval63, ptr %local_81, align 8
+  %call_arg_064 = load { ptr, i64, i64 }, ptr %local_81, align 8
+  %retval65 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_064)
+  store %struct.bcs__BCS %retval65, ptr %local_82, align 8
+  %load_store_tmp66 = load %struct.bcs__BCS, ptr %local_82, align 8
+  store %struct.bcs__BCS %load_store_tmp66, ptr %local_12, align 8
+  %load_store_tmp67 = load i64, ptr %local_30, align 8
+  store i64 %load_store_tmp67, ptr %local_83, align 8
+  store ptr %local_12, ptr %local_84, align 8
+  %call_arg_068 = load ptr, ptr %local_84, align 8
+  %retval69 = call i64 @"0000000000000002_bcs_peel_u64_AL793VCQ2sZbgn"(ptr %call_arg_068)
+  store i64 %retval69, ptr %local_85, align 8
+  %eq_src_070 = load i64, ptr %local_83, align 8
+  %eq_src_171 = load i64, ptr %local_85, align 8
+  %eq_dst72 = icmp eq i64 %eq_src_070, %eq_src_171
+  store i1 %eq_dst72, ptr %local_86, align 1
+  %cnd73 = load i1, ptr %local_86, align 1
+  br i1 %cnd73, label %bb_16, label %bb_15
+
+bb_16:                                            ; preds = %bb_14
+  br label %bb_17
+
+bb_15:                                            ; preds = %bb_14
+  store i64 0, ptr %local_87, align 8
+  %call_arg_074 = load i64, ptr %local_87, align 8
+  call void @move_rt_abort(i64 %call_arg_074)
+  unreachable
+
+bb_17:                                            ; preds = %bb_16
+  store i128 100000000000000000000000000, ptr %local_88, align 8
+  %load_store_tmp75 = load i128, ptr %local_88, align 8
+  store i128 %load_store_tmp75, ptr %local_31, align 8
+  store ptr %local_31, ptr %local_89, align 8
+  %call_arg_076 = load ptr, ptr %local_89, align 8
+  %retval77 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_8jFATsXF3wZTF4"(ptr %call_arg_076)
+  store { ptr, i64, i64 } %retval77, ptr %local_90, align 8
+  %call_arg_078 = load { ptr, i64, i64 }, ptr %local_90, align 8
+  %retval79 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_078)
+  store %struct.bcs__BCS %retval79, ptr %local_91, align 8
+  %load_store_tmp80 = load %struct.bcs__BCS, ptr %local_91, align 8
+  store %struct.bcs__BCS %load_store_tmp80, ptr %local_13, align 8
+  %load_store_tmp81 = load i128, ptr %local_31, align 8
+  store i128 %load_store_tmp81, ptr %local_92, align 8
+  store ptr %local_13, ptr %local_93, align 8
+  %call_arg_082 = load ptr, ptr %local_93, align 8
+  %retval83 = call i128 @"0000000000000002_bcs_peel_u128_NmHT5JzgtEzTCJ"(ptr %call_arg_082)
+  store i128 %retval83, ptr %local_94, align 8
+  %eq_src_084 = load i128, ptr %local_92, align 8
+  %eq_src_185 = load i128, ptr %local_94, align 8
+  %eq_dst86 = icmp eq i128 %eq_src_084, %eq_src_185
+  store i1 %eq_dst86, ptr %local_95, align 1
+  %cnd87 = load i1, ptr %local_95, align 1
+  br i1 %cnd87, label %bb_19, label %bb_18
+
+bb_19:                                            ; preds = %bb_17
+  br label %bb_20
+
+bb_18:                                            ; preds = %bb_17
+  store i64 0, ptr %local_96, align 8
+  %call_arg_088 = load i64, ptr %local_96, align 8
+  call void @move_rt_abort(i64 %call_arg_088)
+  unreachable
+
+bb_20:                                            ; preds = %bb_19
+  %2 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u64)
+  store { ptr, i64, i64 } %2, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u64, ptr %newv, ptr @vdesc.12)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_97, align 8
+  %load_store_tmp89 = load { ptr, i64, i64 }, ptr %local_97, align 8
+  store { ptr, i64, i64 } %load_store_tmp89, ptr %local_32, align 8
+  store ptr %local_32, ptr %local_98, align 8
+  %call_arg_090 = load ptr, ptr %local_98, align 8
+  %retval91 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_5WzzmfEmjB8Pdw"(ptr %call_arg_090)
+  store { ptr, i64, i64 } %retval91, ptr %local_99, align 8
+  %call_arg_092 = load { ptr, i64, i64 }, ptr %local_99, align 8
+  %retval93 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_092)
+  store %struct.bcs__BCS %retval93, ptr %local_100, align 8
+  %load_store_tmp94 = load %struct.bcs__BCS, ptr %local_100, align 8
+  store %struct.bcs__BCS %load_store_tmp94, ptr %local_14, align 8
+  store ptr %local_32, ptr %local_101, align 8
+  %loaded_alloca = load ptr, ptr %local_101, align 8
+  %retval95 = call i64 @move_native_vector_length(ptr @__move_rttydesc_u64, ptr %loaded_alloca)
+  store i64 %retval95, ptr %local_102, align 8
+  store ptr %local_14, ptr %local_103, align 8
+  %call_arg_096 = load ptr, ptr %local_103, align 8
+  %retval97 = call i64 @"0000000000000002_bcs_peel_vec_length_HNqBjL6pYANzcQ"(ptr %call_arg_096)
+  store i64 %retval97, ptr %local_104, align 8
+  %eq_src_098 = load i64, ptr %local_102, align 8
+  %eq_src_199 = load i64, ptr %local_104, align 8
+  %eq_dst100 = icmp eq i64 %eq_src_098, %eq_src_199
+  store i1 %eq_dst100, ptr %local_105, align 1
+  %cnd101 = load i1, ptr %local_105, align 1
+  br i1 %cnd101, label %bb_22, label %bb_21
+
+bb_22:                                            ; preds = %bb_20
+  br label %bb_23
+
+bb_21:                                            ; preds = %bb_20
+  store i64 0, ptr %local_106, align 8
+  %call_arg_0102 = load i64, ptr %local_106, align 8
+  call void @move_rt_abort(i64 %call_arg_0102)
+  unreachable
+
+bb_23:                                            ; preds = %bb_22
+  %3 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u64)
+  store { ptr, i64, i64 } %3, ptr %newv103, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u64, ptr %newv103, ptr @vdesc.14)
+  %reload104 = load { ptr, i64, i64 }, ptr %newv103, align 8
+  store { ptr, i64, i64 } %reload104, ptr %local_107, align 8
+  %load_store_tmp105 = load { ptr, i64, i64 }, ptr %local_107, align 8
+  store { ptr, i64, i64 } %load_store_tmp105, ptr %local_33, align 8
+  store ptr %local_33, ptr %local_108, align 8
+  %call_arg_0106 = load ptr, ptr %local_108, align 8
+  %retval107 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_5WzzmfEmjB8Pdw"(ptr %call_arg_0106)
+  store { ptr, i64, i64 } %retval107, ptr %local_109, align 8
+  %call_arg_0108 = load { ptr, i64, i64 }, ptr %local_109, align 8
+  %retval109 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_0108)
+  store %struct.bcs__BCS %retval109, ptr %local_110, align 8
+  %load_store_tmp110 = load %struct.bcs__BCS, ptr %local_110, align 8
+  store %struct.bcs__BCS %load_store_tmp110, ptr %local_15, align 8
+  store ptr %local_33, ptr %local_111, align 8
+  %loaded_alloca111 = load ptr, ptr %local_111, align 8
+  %retval112 = call i64 @move_native_vector_length(ptr @__move_rttydesc_u64, ptr %loaded_alloca111)
+  store i64 %retval112, ptr %local_112, align 8
+  store ptr %local_15, ptr %local_113, align 8
+  %call_arg_0113 = load ptr, ptr %local_113, align 8
+  %retval114 = call i64 @"0000000000000002_bcs_peel_vec_length_HNqBjL6pYANzcQ"(ptr %call_arg_0113)
+  store i64 %retval114, ptr %local_114, align 8
+  %eq_src_0115 = load i64, ptr %local_112, align 8
+  %eq_src_1116 = load i64, ptr %local_114, align 8
+  %eq_dst117 = icmp eq i64 %eq_src_0115, %eq_src_1116
+  store i1 %eq_dst117, ptr %local_115, align 1
+  %cnd118 = load i1, ptr %local_115, align 1
+  br i1 %cnd118, label %bb_25, label %bb_24
+
+bb_25:                                            ; preds = %bb_23
+  br label %bb_26
+
+bb_24:                                            ; preds = %bb_23
+  store i64 0, ptr %local_116, align 8
+  %call_arg_0119 = load i64, ptr %local_116, align 8
+  call void @move_rt_abort(i64 %call_arg_0119)
+  unreachable
+
+bb_26:                                            ; preds = %bb_25
+  store i1 true, ptr %local_117__a, align 1
+  store i8 100, ptr %local_118__b, align 1
+  store i64 9999, ptr %local_119__c, align 8
+  store i128 112333, ptr %local_120__d, align 8
+  %4 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_bool)
+  store { ptr, i64, i64 } %4, ptr %newv120, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_bool, ptr %newv120, ptr @vdesc.16)
+  %reload121 = load { ptr, i64, i64 }, ptr %newv120, align 8
+  store { ptr, i64, i64 } %reload121, ptr %local_121__k, align 8
+  %5 = load [32 x i8], ptr @acct.addr.17, align 1
+  store [32 x i8] %5, ptr %local_122__s, align 1
+  %fv.0 = load i1, ptr %local_117__a, align 1
+  %fv.1 = load i8, ptr %local_118__b, align 1
+  %fv.2 = load i64, ptr %local_119__c, align 8
+  %fv.3 = load i128, ptr %local_120__d, align 8
+  %fv.4 = load { ptr, i64, i64 }, ptr %local_121__k, align 8
+  %fv.5 = load [32 x i8], ptr %local_122__s, align 1
+  %insert_0 = insertvalue %struct.bcs__Info undef, i1 %fv.0, 0
+  %insert_1 = insertvalue %struct.bcs__Info %insert_0, i8 %fv.1, 1
+  %insert_2 = insertvalue %struct.bcs__Info %insert_1, i64 %fv.2, 2
+  %insert_3 = insertvalue %struct.bcs__Info %insert_2, i128 %fv.3, 3
+  %insert_4 = insertvalue %struct.bcs__Info %insert_3, { ptr, i64, i64 } %fv.4, 4
+  %insert_5 = insertvalue %struct.bcs__Info %insert_4, [32 x i8] %fv.5, 5
+  store %struct.bcs__Info %insert_5, ptr %local_123, align 8
+  %load_store_tmp122 = load %struct.bcs__Info, ptr %local_123, align 8
+  store %struct.bcs__Info %load_store_tmp122, ptr %local_17, align 8
+  store ptr %local_17, ptr %local_124, align 8
+  %call_arg_0123 = load ptr, ptr %local_124, align 8
+  %retval124 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_2KB9WoxsyioRdQ"(ptr %call_arg_0123)
+  store { ptr, i64, i64 } %retval124, ptr %local_125, align 8
+  %call_arg_0125 = load { ptr, i64, i64 }, ptr %local_125, align 8
+  %retval126 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_0125)
+  store %struct.bcs__BCS %retval126, ptr %local_126, align 8
+  %load_store_tmp127 = load %struct.bcs__BCS, ptr %local_126, align 8
+  store %struct.bcs__BCS %load_store_tmp127, ptr %local_1, align 8
+  store ptr %local_17, ptr %local_127, align 8
+  %tmp = load ptr, ptr %local_127, align 8
+  %fld_ref = getelementptr inbounds %struct.bcs__Info, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_128__a, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_128__a, align 8
+  %load_deref_store_tmp2 = load i1, ptr %load_deref_store_tmp1, align 1
+  store i1 %load_deref_store_tmp2, ptr %local_129, align 1
+  store ptr %local_1, ptr %local_130, align 8
+  %call_arg_0128 = load ptr, ptr %local_130, align 8
+  %retval129 = call i1 @"0000000000000002_bcs_peel_bool_3uzNfP9g7KxJxU"(ptr %call_arg_0128)
+  store i1 %retval129, ptr %local_131, align 1
+  %eq_src_0130 = load i1, ptr %local_129, align 1
+  %eq_src_1131 = load i1, ptr %local_131, align 1
+  %eq_dst132 = icmp eq i1 %eq_src_0130, %eq_src_1131
+  store i1 %eq_dst132, ptr %local_132, align 1
+  %cnd133 = load i1, ptr %local_132, align 1
+  br i1 %cnd133, label %bb_28, label %bb_27
+
+bb_28:                                            ; preds = %bb_26
+  br label %bb_29
+
+bb_27:                                            ; preds = %bb_26
+  store i64 0, ptr %local_133, align 8
+  %call_arg_0134 = load i64, ptr %local_133, align 8
+  call void @move_rt_abort(i64 %call_arg_0134)
+  unreachable
+
+bb_29:                                            ; preds = %bb_28
+  store ptr %local_17, ptr %local_134, align 8
+  %tmp135 = load ptr, ptr %local_134, align 8
+  %fld_ref136 = getelementptr inbounds %struct.bcs__Info, ptr %tmp135, i32 0, i32 1
+  store ptr %fld_ref136, ptr %local_135__b, align 8
+  %load_deref_store_tmp1137 = load ptr, ptr %local_135__b, align 8
+  %load_deref_store_tmp2138 = load i8, ptr %load_deref_store_tmp1137, align 1
+  store i8 %load_deref_store_tmp2138, ptr %local_136, align 1
+  store ptr %local_1, ptr %local_137, align 8
+  %call_arg_0139 = load ptr, ptr %local_137, align 8
+  %retval140 = call i8 @"0000000000000002_bcs_peel_u8_6d6AGS42yhTNFk"(ptr %call_arg_0139)
+  store i8 %retval140, ptr %local_138, align 1
+  %eq_src_0141 = load i8, ptr %local_136, align 1
+  %eq_src_1142 = load i8, ptr %local_138, align 1
+  %eq_dst143 = icmp eq i8 %eq_src_0141, %eq_src_1142
+  store i1 %eq_dst143, ptr %local_139, align 1
+  %cnd144 = load i1, ptr %local_139, align 1
+  br i1 %cnd144, label %bb_31, label %bb_30
+
+bb_31:                                            ; preds = %bb_29
+  br label %bb_32
+
+bb_30:                                            ; preds = %bb_29
+  store i64 0, ptr %local_140, align 8
+  %call_arg_0145 = load i64, ptr %local_140, align 8
+  call void @move_rt_abort(i64 %call_arg_0145)
+  unreachable
+
+bb_32:                                            ; preds = %bb_31
+  store ptr %local_17, ptr %local_141, align 8
+  %tmp146 = load ptr, ptr %local_141, align 8
+  %fld_ref147 = getelementptr inbounds %struct.bcs__Info, ptr %tmp146, i32 0, i32 2
+  store ptr %fld_ref147, ptr %local_142__c, align 8
+  %load_deref_store_tmp1148 = load ptr, ptr %local_142__c, align 8
+  %load_deref_store_tmp2149 = load i64, ptr %load_deref_store_tmp1148, align 8
+  store i64 %load_deref_store_tmp2149, ptr %local_143, align 8
+  store ptr %local_1, ptr %local_144, align 8
+  %call_arg_0150 = load ptr, ptr %local_144, align 8
+  %retval151 = call i64 @"0000000000000002_bcs_peel_u64_AL793VCQ2sZbgn"(ptr %call_arg_0150)
+  store i64 %retval151, ptr %local_145, align 8
+  %eq_src_0152 = load i64, ptr %local_143, align 8
+  %eq_src_1153 = load i64, ptr %local_145, align 8
+  %eq_dst154 = icmp eq i64 %eq_src_0152, %eq_src_1153
+  store i1 %eq_dst154, ptr %local_146, align 1
+  %cnd155 = load i1, ptr %local_146, align 1
+  br i1 %cnd155, label %bb_34, label %bb_33
+
+bb_34:                                            ; preds = %bb_32
+  br label %bb_35
+
+bb_33:                                            ; preds = %bb_32
+  store i64 0, ptr %local_147, align 8
+  %call_arg_0156 = load i64, ptr %local_147, align 8
+  call void @move_rt_abort(i64 %call_arg_0156)
+  unreachable
+
+bb_35:                                            ; preds = %bb_34
+  store ptr %local_17, ptr %local_148, align 8
+  %tmp157 = load ptr, ptr %local_148, align 8
+  %fld_ref158 = getelementptr inbounds %struct.bcs__Info, ptr %tmp157, i32 0, i32 3
+  store ptr %fld_ref158, ptr %local_149__d, align 8
+  %load_deref_store_tmp1159 = load ptr, ptr %local_149__d, align 8
+  %load_deref_store_tmp2160 = load i128, ptr %load_deref_store_tmp1159, align 8
+  store i128 %load_deref_store_tmp2160, ptr %local_150, align 8
+  store ptr %local_1, ptr %local_151, align 8
+  %call_arg_0161 = load ptr, ptr %local_151, align 8
+  %retval162 = call i128 @"0000000000000002_bcs_peel_u128_NmHT5JzgtEzTCJ"(ptr %call_arg_0161)
+  store i128 %retval162, ptr %local_152, align 8
+  %eq_src_0163 = load i128, ptr %local_150, align 8
+  %eq_src_1164 = load i128, ptr %local_152, align 8
+  %eq_dst165 = icmp eq i128 %eq_src_0163, %eq_src_1164
+  store i1 %eq_dst165, ptr %local_153, align 1
+  %cnd166 = load i1, ptr %local_153, align 1
+  br i1 %cnd166, label %bb_37, label %bb_36
+
+bb_37:                                            ; preds = %bb_35
+  br label %bb_38
+
+bb_36:                                            ; preds = %bb_35
+  store i64 0, ptr %local_154, align 8
+  %call_arg_0167 = load i64, ptr %local_154, align 8
+  call void @move_rt_abort(i64 %call_arg_0167)
+  unreachable
+
+bb_38:                                            ; preds = %bb_37
+  store ptr %local_1, ptr %local_155, align 8
+  %call_arg_0168 = load ptr, ptr %local_155, align 8
+  %retval169 = call i64 @"0000000000000002_bcs_peel_vec_length_HNqBjL6pYANzcQ"(ptr %call_arg_0168)
+  store i64 %retval169, ptr %local_156, align 8
+  %load_store_tmp170 = load i64, ptr %local_156, align 8
+  store i64 %load_store_tmp170, ptr %local_18, align 8
+  store ptr %local_17, ptr %local_157, align 8
+  %tmp171 = load ptr, ptr %local_157, align 8
+  %fld_ref172 = getelementptr inbounds %struct.bcs__Info, ptr %tmp171, i32 0, i32 4
+  store ptr %fld_ref172, ptr %local_158__k, align 8
+  %loaded_alloca173 = load ptr, ptr %local_158__k, align 8
+  %retval174 = call i64 @move_native_vector_length(ptr @__move_rttydesc_bool, ptr %loaded_alloca173)
+  store i64 %retval174, ptr %local_159, align 8
+  %load_store_tmp175 = load i64, ptr %local_18, align 8
+  store i64 %load_store_tmp175, ptr %local_160, align 8
+  %eq_src_0176 = load i64, ptr %local_159, align 8
+  %eq_src_1177 = load i64, ptr %local_160, align 8
+  %eq_dst178 = icmp eq i64 %eq_src_0176, %eq_src_1177
+  store i1 %eq_dst178, ptr %local_161, align 1
+  %cnd179 = load i1, ptr %local_161, align 1
+  br i1 %cnd179, label %bb_40, label %bb_39
+
+bb_40:                                            ; preds = %bb_38
+  br label %bb_41
+
+bb_39:                                            ; preds = %bb_38
+  store i64 0, ptr %local_162, align 8
+  %call_arg_0180 = load i64, ptr %local_162, align 8
+  call void @move_rt_abort(i64 %call_arg_0180)
+  unreachable
+
+bb_41:                                            ; preds = %bb_40
+  store i64 0, ptr %local_163, align 8
+  %load_store_tmp181 = load i64, ptr %local_163, align 8
+  store i64 %load_store_tmp181, ptr %local_16, align 8
+  br label %bb_48
+
+bb_48:                                            ; preds = %join_bb, %bb_41
+  %load_store_tmp182 = load i64, ptr %local_16, align 8
+  store i64 %load_store_tmp182, ptr %local_164, align 8
+  store ptr %local_17, ptr %local_165, align 8
+  %tmp183 = load ptr, ptr %local_165, align 8
+  %fld_ref184 = getelementptr inbounds %struct.bcs__Info, ptr %tmp183, i32 0, i32 4
+  store ptr %fld_ref184, ptr %local_166__k, align 8
+  %loaded_alloca185 = load ptr, ptr %local_166__k, align 8
+  %retval186 = call i64 @move_native_vector_length(ptr @__move_rttydesc_bool, ptr %loaded_alloca185)
+  store i64 %retval186, ptr %local_167, align 8
+  %lt_src_0 = load i64, ptr %local_164, align 8
+  %lt_src_1 = load i64, ptr %local_167, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_168, align 1
+  %cnd187 = load i1, ptr %local_168, align 1
+  br i1 %cnd187, label %bb_43, label %bb_42
+
+bb_43:                                            ; preds = %bb_48
+  br label %bb_44
+
+bb_44:                                            ; preds = %bb_43
+  store ptr %local_17, ptr %local_169, align 8
+  %tmp188 = load ptr, ptr %local_169, align 8
+  %fld_ref189 = getelementptr inbounds %struct.bcs__Info, ptr %tmp188, i32 0, i32 4
+  store ptr %fld_ref189, ptr %local_170__k, align 8
+  %load_store_tmp190 = load i64, ptr %local_16, align 8
+  store i64 %load_store_tmp190, ptr %local_171, align 8
+  %loaded_alloca191 = load ptr, ptr %local_170__k, align 8
+  %loaded_alloca192 = load i64, ptr %local_171, align 8
+  %retval193 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_bool, ptr %loaded_alloca191, i64 %loaded_alloca192)
+  store ptr %retval193, ptr %local_172, align 8
+  %load_deref_store_tmp1194 = load ptr, ptr %local_172, align 8
+  %load_deref_store_tmp2195 = load i1, ptr %load_deref_store_tmp1194, align 1
+  store i1 %load_deref_store_tmp2195, ptr %local_173, align 1
+  store ptr %local_1, ptr %local_174, align 8
+  %call_arg_0196 = load ptr, ptr %local_174, align 8
+  %retval197 = call i1 @"0000000000000002_bcs_peel_bool_3uzNfP9g7KxJxU"(ptr %call_arg_0196)
+  store i1 %retval197, ptr %local_175, align 1
+  %eq_src_0198 = load i1, ptr %local_173, align 1
+  %eq_src_1199 = load i1, ptr %local_175, align 1
+  %eq_dst200 = icmp eq i1 %eq_src_0198, %eq_src_1199
+  store i1 %eq_dst200, ptr %local_176, align 1
+  %cnd201 = load i1, ptr %local_176, align 1
+  br i1 %cnd201, label %bb_46, label %bb_45
+
+bb_46:                                            ; preds = %bb_44
+  br label %bb_47
+
+bb_45:                                            ; preds = %bb_44
+  store i64 0, ptr %local_177, align 8
+  %call_arg_0202 = load i64, ptr %local_177, align 8
+  call void @move_rt_abort(i64 %call_arg_0202)
+  unreachable
+
+bb_47:                                            ; preds = %bb_46
+  %load_store_tmp203 = load i64, ptr %local_16, align 8
+  store i64 %load_store_tmp203, ptr %local_178, align 8
+  store i64 1, ptr %local_179, align 8
+  %add_src_0 = load i64, ptr %local_178, align 8
+  %add_src_1 = load i64, ptr %local_179, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_47
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_47
+  store i64 %add_dst, ptr %local_180, align 8
+  %load_store_tmp204 = load i64, ptr %local_180, align 8
+  store i64 %load_store_tmp204, ptr %local_16, align 8
+  br label %bb_48
+
+bb_42:                                            ; preds = %bb_48
+  store ptr %local_17, ptr %local_181, align 8
+  %tmp205 = load ptr, ptr %local_181, align 8
+  %fld_ref206 = getelementptr inbounds %struct.bcs__Info, ptr %tmp205, i32 0, i32 5
+  store ptr %fld_ref206, ptr %local_182__s, align 8
+  %load_deref_store_tmp1207 = load ptr, ptr %local_182__s, align 8
+  %load_deref_store_tmp2208 = load [32 x i8], ptr %load_deref_store_tmp1207, align 1
+  store [32 x i8] %load_deref_store_tmp2208, ptr %local_183, align 1
+  store ptr %local_1, ptr %local_184, align 8
+  %call_arg_0209 = load ptr, ptr %local_184, align 8
+  %retval210 = call [32 x i8] @"0000000000000002_bcs_peel_address_6ieY385GfzQPhi"(ptr %call_arg_0209)
+  store [32 x i8] %retval210, ptr %local_185, align 1
+  %6 = call i32 @memcmp(ptr %local_183, ptr %local_185, i64 32)
+  %eq_dst211 = icmp eq i32 %6, 0
+  store i1 %eq_dst211, ptr %local_186, align 1
+  %cnd212 = load i1, ptr %local_186, align 1
+  br i1 %cnd212, label %bb_50, label %bb_49
+
+bb_50:                                            ; preds = %bb_42
+  br label %bb_51
+
+bb_49:                                            ; preds = %bb_42
+  store i64 0, ptr %local_187, align 8
+  %call_arg_0213 = load i64, ptr %local_187, align 8
+  call void @move_rt_abort(i64 %call_arg_0213)
+  unreachable
+
+bb_51:                                            ; preds = %bb_50
+  %7 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %7, ptr %newv214, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv214, ptr @vdesc.19)
+  %reload215 = load { ptr, i64, i64 }, ptr %newv214, align 8
+  store { ptr, i64, i64 } %reload215, ptr %local_188, align 8
+  %load_store_tmp216 = load { ptr, i64, i64 }, ptr %local_188, align 8
+  store { ptr, i64, i64 } %load_store_tmp216, ptr %local_20, align 8
+  store ptr %local_20, ptr %local_189, align 8
+  %call_arg_0217 = load ptr, ptr %local_189, align 8
+  %retval218 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_BbXdzaNHt75BkF"(ptr %call_arg_0217)
+  store { ptr, i64, i64 } %retval218, ptr %local_190, align 8
+  %call_arg_0219 = load { ptr, i64, i64 }, ptr %local_190, align 8
+  %retval220 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_0219)
+  store %struct.bcs__BCS %retval220, ptr %local_191, align 8
+  %load_store_tmp221 = load %struct.bcs__BCS, ptr %local_191, align 8
+  store %struct.bcs__BCS %load_store_tmp221, ptr %local_2, align 8
+  %load_store_tmp222 = load { ptr, i64, i64 }, ptr %local_20, align 8
+  store { ptr, i64, i64 } %load_store_tmp222, ptr %local_192, align 8
+  store ptr %local_2, ptr %local_193, align 8
+  %call_arg_0223 = load ptr, ptr %local_193, align 8
+  %retval224 = call { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_vec_u8_7PcPmN6rdUgmA9"(ptr %call_arg_0223)
+  store { ptr, i64, i64 } %retval224, ptr %local_194, align 8
+  %8 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_vector_u8_, ptr %local_192, ptr %local_194)
+  store i1 %8, ptr %local_195, align 1
+  %cnd225 = load i1, ptr %local_195, align 1
+  br i1 %cnd225, label %bb_53, label %bb_52
+
+bb_53:                                            ; preds = %bb_51
+  br label %bb_54
+
+bb_52:                                            ; preds = %bb_51
+  store i64 0, ptr %local_196, align 8
+  %call_arg_0226 = load i64, ptr %local_196, align 8
+  call void @move_rt_abort(i64 %call_arg_0226)
+  unreachable
+
+bb_54:                                            ; preds = %bb_53
+  %9 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %9, ptr %newv227, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv227, ptr @vdesc.21)
+  %reload228 = load { ptr, i64, i64 }, ptr %newv227, align 8
+  store { ptr, i64, i64 } %reload228, ptr %local_197, align 8
+  %load_store_tmp229 = load { ptr, i64, i64 }, ptr %local_197, align 8
+  store { ptr, i64, i64 } %load_store_tmp229, ptr %local_21, align 8
+  store ptr %local_21, ptr %local_198, align 8
+  %call_arg_0230 = load ptr, ptr %local_198, align 8
+  %retval231 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_eudXMbiaBkW7t2"(ptr %call_arg_0230)
+  store { ptr, i64, i64 } %retval231, ptr %local_199, align 8
+  %call_arg_0232 = load { ptr, i64, i64 }, ptr %local_199, align 8
+  %retval233 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_0232)
+  store %struct.bcs__BCS %retval233, ptr %local_200, align 8
+  %load_store_tmp234 = load %struct.bcs__BCS, ptr %local_200, align 8
+  store %struct.bcs__BCS %load_store_tmp234, ptr %local_3, align 8
+  %load_store_tmp235 = load { ptr, i64, i64 }, ptr %local_21, align 8
+  store { ptr, i64, i64 } %load_store_tmp235, ptr %local_201, align 8
+  store ptr %local_3, ptr %local_202, align 8
+  %call_arg_0236 = load ptr, ptr %local_202, align 8
+  %retval237 = call { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_u8_4z7Az3QuZfeaFB"(ptr %call_arg_0236)
+  store { ptr, i64, i64 } %retval237, ptr %local_203, align 8
+  %10 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_201, ptr %local_203)
+  store i1 %10, ptr %local_204, align 1
+  %cnd238 = load i1, ptr %local_204, align 1
+  br i1 %cnd238, label %bb_56, label %bb_55
+
+bb_56:                                            ; preds = %bb_54
+  br label %bb_57
+
+bb_55:                                            ; preds = %bb_54
+  store i64 0, ptr %local_205, align 8
+  %call_arg_0239 = load i64, ptr %local_205, align 8
+  call void @move_rt_abort(i64 %call_arg_0239)
+  unreachable
+
+bb_57:                                            ; preds = %bb_56
+  %11 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u64)
+  store { ptr, i64, i64 } %11, ptr %newv240, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u64, ptr %newv240, ptr @vdesc.23)
+  %reload241 = load { ptr, i64, i64 }, ptr %newv240, align 8
+  store { ptr, i64, i64 } %reload241, ptr %local_206, align 8
+  %load_store_tmp242 = load { ptr, i64, i64 }, ptr %local_206, align 8
+  store { ptr, i64, i64 } %load_store_tmp242, ptr %local_22, align 8
+  store ptr %local_22, ptr %local_207, align 8
+  %call_arg_0243 = load ptr, ptr %local_207, align 8
+  %retval244 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_5WzzmfEmjB8Pdw"(ptr %call_arg_0243)
+  store { ptr, i64, i64 } %retval244, ptr %local_208, align 8
+  %call_arg_0245 = load { ptr, i64, i64 }, ptr %local_208, align 8
+  %retval246 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_0245)
+  store %struct.bcs__BCS %retval246, ptr %local_209, align 8
+  %load_store_tmp247 = load %struct.bcs__BCS, ptr %local_209, align 8
+  store %struct.bcs__BCS %load_store_tmp247, ptr %local_4, align 8
+  %load_store_tmp248 = load { ptr, i64, i64 }, ptr %local_22, align 8
+  store { ptr, i64, i64 } %load_store_tmp248, ptr %local_210, align 8
+  store ptr %local_4, ptr %local_211, align 8
+  %call_arg_0249 = load ptr, ptr %local_211, align 8
+  %retval250 = call { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_u64_DNtE2HaiuV6VEn"(ptr %call_arg_0249)
+  store { ptr, i64, i64 } %retval250, ptr %local_212, align 8
+  %12 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u64, ptr %local_210, ptr %local_212)
+  store i1 %12, ptr %local_213, align 1
+  %cnd251 = load i1, ptr %local_213, align 1
+  br i1 %cnd251, label %bb_59, label %bb_58
+
+bb_59:                                            ; preds = %bb_57
+  br label %bb_60
+
+bb_58:                                            ; preds = %bb_57
+  store i64 0, ptr %local_214, align 8
+  %call_arg_0252 = load i64, ptr %local_214, align 8
+  call void @move_rt_abort(i64 %call_arg_0252)
+  unreachable
+
+bb_60:                                            ; preds = %bb_59
+  %13 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u128)
+  store { ptr, i64, i64 } %13, ptr %newv253, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u128, ptr %newv253, ptr @vdesc.25)
+  %reload254 = load { ptr, i64, i64 }, ptr %newv253, align 8
+  store { ptr, i64, i64 } %reload254, ptr %local_215, align 8
+  %load_store_tmp255 = load { ptr, i64, i64 }, ptr %local_215, align 8
+  store { ptr, i64, i64 } %load_store_tmp255, ptr %local_23, align 8
+  store ptr %local_23, ptr %local_216, align 8
+  %call_arg_0256 = load ptr, ptr %local_216, align 8
+  %retval257 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_BneHuqjWsnGTzt"(ptr %call_arg_0256)
+  store { ptr, i64, i64 } %retval257, ptr %local_217, align 8
+  %call_arg_0258 = load { ptr, i64, i64 }, ptr %local_217, align 8
+  %retval259 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_0258)
+  store %struct.bcs__BCS %retval259, ptr %local_218, align 8
+  %load_store_tmp260 = load %struct.bcs__BCS, ptr %local_218, align 8
+  store %struct.bcs__BCS %load_store_tmp260, ptr %local_5, align 8
+  %load_store_tmp261 = load { ptr, i64, i64 }, ptr %local_23, align 8
+  store { ptr, i64, i64 } %load_store_tmp261, ptr %local_219, align 8
+  store ptr %local_5, ptr %local_220, align 8
+  %call_arg_0262 = load ptr, ptr %local_220, align 8
+  %retval263 = call { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_u128_FkuW25NBimnBdr"(ptr %call_arg_0262)
+  store { ptr, i64, i64 } %retval263, ptr %local_221, align 8
+  %14 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u128, ptr %local_219, ptr %local_221)
+  store i1 %14, ptr %local_222, align 1
+  %cnd264 = load i1, ptr %local_222, align 1
+  br i1 %cnd264, label %bb_62, label %bb_61
+
+bb_62:                                            ; preds = %bb_60
+  br label %bb_63
+
+bb_61:                                            ; preds = %bb_60
+  store i64 0, ptr %local_223, align 8
+  %call_arg_0265 = load i64, ptr %local_223, align 8
+  call void @move_rt_abort(i64 %call_arg_0265)
+  unreachable
+
+bb_63:                                            ; preds = %bb_62
+  %15 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_bool)
+  store { ptr, i64, i64 } %15, ptr %newv266, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_bool, ptr %newv266, ptr @vdesc.27)
+  %reload267 = load { ptr, i64, i64 }, ptr %newv266, align 8
+  store { ptr, i64, i64 } %reload267, ptr %local_224, align 8
+  %load_store_tmp268 = load { ptr, i64, i64 }, ptr %local_224, align 8
+  store { ptr, i64, i64 } %load_store_tmp268, ptr %local_24, align 8
+  store ptr %local_24, ptr %local_225, align 8
+  %call_arg_0269 = load ptr, ptr %local_225, align 8
+  %retval270 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_8QkbRJ3bz4rnNL"(ptr %call_arg_0269)
+  store { ptr, i64, i64 } %retval270, ptr %local_226, align 8
+  %call_arg_0271 = load { ptr, i64, i64 }, ptr %local_226, align 8
+  %retval272 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_0271)
+  store %struct.bcs__BCS %retval272, ptr %local_227, align 8
+  %load_store_tmp273 = load %struct.bcs__BCS, ptr %local_227, align 8
+  store %struct.bcs__BCS %load_store_tmp273, ptr %local_6, align 8
+  %load_store_tmp274 = load { ptr, i64, i64 }, ptr %local_24, align 8
+  store { ptr, i64, i64 } %load_store_tmp274, ptr %local_228, align 8
+  store ptr %local_6, ptr %local_229, align 8
+  %call_arg_0275 = load ptr, ptr %local_229, align 8
+  %retval276 = call { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_bool_55BoGbJggFCRbo"(ptr %call_arg_0275)
+  store { ptr, i64, i64 } %retval276, ptr %local_230, align 8
+  %16 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_bool, ptr %local_228, ptr %local_230)
+  store i1 %16, ptr %local_231, align 1
+  %cnd277 = load i1, ptr %local_231, align 1
+  br i1 %cnd277, label %bb_65, label %bb_64
+
+bb_65:                                            ; preds = %bb_63
+  br label %bb_66
+
+bb_64:                                            ; preds = %bb_63
+  store i64 0, ptr %local_232, align 8
+  %call_arg_0278 = load i64, ptr %local_232, align 8
+  call void @move_rt_abort(i64 %call_arg_0278)
+  unreachable
+
+bb_66:                                            ; preds = %bb_65
+  %17 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_address)
+  store { ptr, i64, i64 } %17, ptr %newv279, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_address, ptr %newv279, ptr @vdesc.29)
+  %reload280 = load { ptr, i64, i64 }, ptr %newv279, align 8
+  store { ptr, i64, i64 } %reload280, ptr %local_233, align 8
+  %load_store_tmp281 = load { ptr, i64, i64 }, ptr %local_233, align 8
+  store { ptr, i64, i64 } %load_store_tmp281, ptr %local_25, align 8
+  store ptr %local_25, ptr %local_234, align 8
+  %call_arg_0282 = load ptr, ptr %local_234, align 8
+  %retval283 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_A65EFLn59ufQ8Z"(ptr %call_arg_0282)
+  store { ptr, i64, i64 } %retval283, ptr %local_235, align 8
+  %call_arg_0284 = load { ptr, i64, i64 }, ptr %local_235, align 8
+  %retval285 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_0284)
+  store %struct.bcs__BCS %retval285, ptr %local_236, align 8
+  %load_store_tmp286 = load %struct.bcs__BCS, ptr %local_236, align 8
+  store %struct.bcs__BCS %load_store_tmp286, ptr %local_7, align 8
+  %load_store_tmp287 = load { ptr, i64, i64 }, ptr %local_25, align 8
+  store { ptr, i64, i64 } %load_store_tmp287, ptr %local_237, align 8
+  store ptr %local_7, ptr %local_238, align 8
+  %call_arg_0288 = load ptr, ptr %local_238, align 8
+  %retval289 = call { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_addres_7uWkV96TiaFJqe"(ptr %call_arg_0288)
+  store { ptr, i64, i64 } %retval289, ptr %local_239, align 8
+  %18 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_address, ptr %local_237, ptr %local_239)
+  store i1 %18, ptr %local_240, align 1
+  %cnd290 = load i1, ptr %local_240, align 1
+  br i1 %cnd290, label %bb_68, label %bb_67
+
+bb_68:                                            ; preds = %bb_66
+  br label %bb_69
+
+bb_67:                                            ; preds = %bb_66
+  store i64 0, ptr %local_241, align 8
+  %call_arg_0291 = load i64, ptr %local_241, align 8
+  call void @move_rt_abort(i64 %call_arg_0291)
+  unreachable
+
+bb_69:                                            ; preds = %bb_68
+  ret void
+}
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_6z6DhCEHM2cfNu"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_address, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+declare { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr, ptr)
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_4uemf4C6AKb21F"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_bool, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_27yEv5Fct1GqPE"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_6NhXVWFo2aWmc9"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_u64, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_8jFATsXF3wZTF4"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_u128, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_5WzzmfEmjB8Pdw"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_vector_u64_, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_2KB9WoxsyioRdQ"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_bcs__Info, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+declare ptr @move_native_vector_borrow(ptr, ptr, i64)
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_BbXdzaNHt75BkF"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_vector_vector_u8__, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_eudXMbiaBkW7t2"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_vector_u8_, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_BneHuqjWsnGTzt"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_vector_u128_, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_8QkbRJ3bz4rnNL"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_vector_bool_, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_A65EFLn59ufQ8Z"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_vector_address_, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+define private void @"0000000000000002_bcs_test_bool_fail_3nbaH6Xek5wWLQ"() {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca %struct.bcs__BCS, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca { ptr, i64, i64 }, align 8
+  %local_5 = alloca %struct.bcs__BCS, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7 = alloca i1, align 1
+  store i8 10, ptr %local_2, align 1
+  %load_store_tmp = load i8, ptr %local_2, align 1
+  store i8 %load_store_tmp, ptr %local_0, align 1
+  store ptr %local_0, ptr %local_3, align 8
+  %call_arg_0 = load ptr, ptr %local_3, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_27yEv5Fct1GqPE"(ptr %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_4, align 8
+  %call_arg_01 = load { ptr, i64, i64 }, ptr %local_4, align 8
+  %retval2 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_01)
+  store %struct.bcs__BCS %retval2, ptr %local_5, align 8
+  %load_store_tmp3 = load %struct.bcs__BCS, ptr %local_5, align 8
+  store %struct.bcs__BCS %load_store_tmp3, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_6, align 8
+  %call_arg_04 = load ptr, ptr %local_6, align 8
+  %retval5 = call i1 @"0000000000000002_bcs_peel_bool_3uzNfP9g7KxJxU"(ptr %call_arg_04)
+  store i1 %retval5, ptr %local_7, align 1
+  ret void
+}
+
+define private void @"0000000000000002_bcs_test_option_CTTJUgCeRuG6qd"() {
+entry:
+  %local_0 = alloca %struct.bcs__BCS, align 8
+  %local_1 = alloca %struct.bcs__BCS, align 8
+  %local_2 = alloca %struct.bcs__BCS, align 8
+  %local_3 = alloca %struct.bcs__BCS, align 8
+  %local_4 = alloca %struct.bcs__BCS, align 8
+  %local_5 = alloca %struct.bcs__BCS, align 8
+  %local_6 = alloca %struct.option__Option_bool_, align 8
+  %local_7 = alloca %struct.option__Option_u8_, align 8
+  %local_8 = alloca %struct.option__Option_u64_, align 8
+  %local_9 = alloca %struct.option__Option_u128_, align 8
+  %local_10 = alloca %struct.option__Option_address_, align 8
+  %local_11 = alloca %struct.option__Option_bool_, align 8
+  %local_12 = alloca i1, align 1
+  %local_13 = alloca %struct.option__Option_bool_, align 8
+  %local_14 = alloca ptr, align 8
+  %local_15 = alloca { ptr, i64, i64 }, align 8
+  %local_16 = alloca %struct.bcs__BCS, align 8
+  %local_17 = alloca %struct.option__Option_bool_, align 8
+  %local_18 = alloca ptr, align 8
+  %local_19 = alloca %struct.option__Option_bool_, align 8
+  %local_20 = alloca i1, align 1
+  %local_21 = alloca i64, align 8
+  %local_22 = alloca i8, align 1
+  %local_23 = alloca %struct.option__Option_u8_, align 8
+  %local_24 = alloca ptr, align 8
+  %local_25 = alloca { ptr, i64, i64 }, align 8
+  %local_26 = alloca %struct.bcs__BCS, align 8
+  %local_27 = alloca %struct.option__Option_u8_, align 8
+  %local_28 = alloca ptr, align 8
+  %local_29 = alloca %struct.option__Option_u8_, align 8
+  %local_30 = alloca i1, align 1
+  %local_31 = alloca i64, align 8
+  %local_32 = alloca i64, align 8
+  %local_33 = alloca %struct.option__Option_u64_, align 8
+  %local_34 = alloca ptr, align 8
+  %local_35 = alloca { ptr, i64, i64 }, align 8
+  %local_36 = alloca %struct.bcs__BCS, align 8
+  %local_37 = alloca %struct.option__Option_u64_, align 8
+  %local_38 = alloca ptr, align 8
+  %local_39 = alloca %struct.option__Option_u64_, align 8
+  %local_40 = alloca i1, align 1
+  %local_41 = alloca i64, align 8
+  %local_42 = alloca i128, align 8
+  %local_43 = alloca %struct.option__Option_u128_, align 8
+  %local_44 = alloca ptr, align 8
+  %local_45 = alloca { ptr, i64, i64 }, align 8
+  %local_46 = alloca %struct.bcs__BCS, align 8
+  %local_47 = alloca %struct.option__Option_u128_, align 8
+  %local_48 = alloca ptr, align 8
+  %local_49 = alloca %struct.option__Option_u128_, align 8
+  %local_50 = alloca i1, align 1
+  %local_51 = alloca i64, align 8
+  %local_52 = alloca [32 x i8], align 1
+  %local_53 = alloca %struct.option__Option_address_, align 8
+  %local_54 = alloca ptr, align 8
+  %local_55 = alloca { ptr, i64, i64 }, align 8
+  %local_56 = alloca %struct.bcs__BCS, align 8
+  %local_57 = alloca %struct.option__Option_address_, align 8
+  %local_58 = alloca ptr, align 8
+  %local_59 = alloca %struct.option__Option_address_, align 8
+  %local_60 = alloca i1, align 1
+  %local_61 = alloca i64, align 8
+  %local_62 = alloca %struct.option__Option_bool_, align 8
+  %local_63 = alloca ptr, align 8
+  %local_64 = alloca { ptr, i64, i64 }, align 8
+  %local_65 = alloca %struct.bcs__BCS, align 8
+  %local_66 = alloca %struct.option__Option_bool_, align 8
+  %local_67 = alloca ptr, align 8
+  %local_68 = alloca %struct.option__Option_bool_, align 8
+  %local_69 = alloca i1, align 1
+  %local_70 = alloca i64, align 8
+  store i1 true, ptr %local_12, align 1
+  %call_arg_0 = load i1, ptr %local_12, align 1
+  %retval = call %struct.option__Option_bool_ @"0000000000000001_option_some_Ao9SKJoXum3yE1"(i1 %call_arg_0)
+  store %struct.option__Option_bool_ %retval, ptr %local_13, align 8
+  %load_store_tmp = load %struct.option__Option_bool_, ptr %local_13, align 8
+  store %struct.option__Option_bool_ %load_store_tmp, ptr %local_6, align 8
+  store ptr %local_6, ptr %local_14, align 8
+  %call_arg_01 = load ptr, ptr %local_14, align 8
+  %retval2 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_G6s6Uuxhs2JvCy"(ptr %call_arg_01)
+  store { ptr, i64, i64 } %retval2, ptr %local_15, align 8
+  %call_arg_03 = load { ptr, i64, i64 }, ptr %local_15, align 8
+  %retval4 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_03)
+  store %struct.bcs__BCS %retval4, ptr %local_16, align 8
+  %load_store_tmp5 = load %struct.bcs__BCS, ptr %local_16, align 8
+  store %struct.bcs__BCS %load_store_tmp5, ptr %local_0, align 8
+  store ptr %local_0, ptr %local_18, align 8
+  %call_arg_06 = load ptr, ptr %local_18, align 8
+  %retval7 = call %struct.option__Option_bool_ @"0000000000000002_bcs_peel_option_boo_4RJsKiXKvzRAXW"(ptr %call_arg_06)
+  store %struct.option__Option_bool_ %retval7, ptr %local_19, align 8
+  %0 = call i1 @move_rt_struct_cmp_eq(ptr @__move_rttydesc_option__Option_bool_, ptr %local_6, ptr %local_19)
+  store i1 %0, ptr %local_20, align 1
+  %cnd = load i1, ptr %local_20, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i64 0, ptr %local_21, align 8
+  %call_arg_08 = load i64, ptr %local_21, align 8
+  call void @move_rt_abort(i64 %call_arg_08)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  store i8 10, ptr %local_22, align 1
+  %call_arg_09 = load i8, ptr %local_22, align 1
+  %retval10 = call %struct.option__Option_u8_ @"0000000000000001_option_some_xnTx4LiMbuArQQ"(i8 %call_arg_09)
+  store %struct.option__Option_u8_ %retval10, ptr %local_23, align 8
+  %load_store_tmp11 = load %struct.option__Option_u8_, ptr %local_23, align 8
+  store %struct.option__Option_u8_ %load_store_tmp11, ptr %local_7, align 8
+  store ptr %local_7, ptr %local_24, align 8
+  %call_arg_012 = load ptr, ptr %local_24, align 8
+  %retval13 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_34VWcXYqydUD6L"(ptr %call_arg_012)
+  store { ptr, i64, i64 } %retval13, ptr %local_25, align 8
+  %call_arg_014 = load { ptr, i64, i64 }, ptr %local_25, align 8
+  %retval15 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_014)
+  store %struct.bcs__BCS %retval15, ptr %local_26, align 8
+  %load_store_tmp16 = load %struct.bcs__BCS, ptr %local_26, align 8
+  store %struct.bcs__BCS %load_store_tmp16, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_28, align 8
+  %call_arg_017 = load ptr, ptr %local_28, align 8
+  %retval18 = call %struct.option__Option_u8_ @"0000000000000002_bcs_peel_option_u8_CHXhFou58tDHFw"(ptr %call_arg_017)
+  store %struct.option__Option_u8_ %retval18, ptr %local_29, align 8
+  %1 = call i1 @move_rt_struct_cmp_eq(ptr @__move_rttydesc_option__Option_u8_, ptr %local_7, ptr %local_29)
+  store i1 %1, ptr %local_30, align 1
+  %cnd19 = load i1, ptr %local_30, align 1
+  br i1 %cnd19, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  store i64 0, ptr %local_31, align 8
+  %call_arg_020 = load i64, ptr %local_31, align 8
+  call void @move_rt_abort(i64 %call_arg_020)
+  unreachable
+
+bb_5:                                             ; preds = %bb_4
+  store i64 10000, ptr %local_32, align 8
+  %call_arg_021 = load i64, ptr %local_32, align 8
+  %retval22 = call %struct.option__Option_u64_ @"0000000000000001_option_some_4zz2TymghHW1fs"(i64 %call_arg_021)
+  store %struct.option__Option_u64_ %retval22, ptr %local_33, align 8
+  %load_store_tmp23 = load %struct.option__Option_u64_, ptr %local_33, align 8
+  store %struct.option__Option_u64_ %load_store_tmp23, ptr %local_8, align 8
+  store ptr %local_8, ptr %local_34, align 8
+  %call_arg_024 = load ptr, ptr %local_34, align 8
+  %retval25 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_6tpUBfguzJhbz8"(ptr %call_arg_024)
+  store { ptr, i64, i64 } %retval25, ptr %local_35, align 8
+  %call_arg_026 = load { ptr, i64, i64 }, ptr %local_35, align 8
+  %retval27 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_026)
+  store %struct.bcs__BCS %retval27, ptr %local_36, align 8
+  %load_store_tmp28 = load %struct.bcs__BCS, ptr %local_36, align 8
+  store %struct.bcs__BCS %load_store_tmp28, ptr %local_2, align 8
+  store ptr %local_2, ptr %local_38, align 8
+  %call_arg_029 = load ptr, ptr %local_38, align 8
+  %retval30 = call %struct.option__Option_u64_ @"0000000000000002_bcs_peel_option_u64_3WJk1T5bFj4c67"(ptr %call_arg_029)
+  store %struct.option__Option_u64_ %retval30, ptr %local_39, align 8
+  %2 = call i1 @move_rt_struct_cmp_eq(ptr @__move_rttydesc_option__Option_u64_, ptr %local_8, ptr %local_39)
+  store i1 %2, ptr %local_40, align 1
+  %cnd31 = load i1, ptr %local_40, align 1
+  br i1 %cnd31, label %bb_7, label %bb_6
+
+bb_7:                                             ; preds = %bb_5
+  br label %bb_8
+
+bb_6:                                             ; preds = %bb_5
+  store i64 0, ptr %local_41, align 8
+  %call_arg_032 = load i64, ptr %local_41, align 8
+  call void @move_rt_abort(i64 %call_arg_032)
+  unreachable
+
+bb_8:                                             ; preds = %bb_7
+  store i128 10000999999, ptr %local_42, align 8
+  %call_arg_033 = load i128, ptr %local_42, align 8
+  %retval34 = call %struct.option__Option_u128_ @"0000000000000001_option_some_7TwgxN8n15ac7N"(i128 %call_arg_033)
+  store %struct.option__Option_u128_ %retval34, ptr %local_43, align 8
+  %load_store_tmp35 = load %struct.option__Option_u128_, ptr %local_43, align 8
+  store %struct.option__Option_u128_ %load_store_tmp35, ptr %local_9, align 8
+  store ptr %local_9, ptr %local_44, align 8
+  %call_arg_036 = load ptr, ptr %local_44, align 8
+  %retval37 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_42cyBZkxm74pJ6"(ptr %call_arg_036)
+  store { ptr, i64, i64 } %retval37, ptr %local_45, align 8
+  %call_arg_038 = load { ptr, i64, i64 }, ptr %local_45, align 8
+  %retval39 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_038)
+  store %struct.bcs__BCS %retval39, ptr %local_46, align 8
+  %load_store_tmp40 = load %struct.bcs__BCS, ptr %local_46, align 8
+  store %struct.bcs__BCS %load_store_tmp40, ptr %local_3, align 8
+  store ptr %local_3, ptr %local_48, align 8
+  %call_arg_041 = load ptr, ptr %local_48, align 8
+  %retval42 = call %struct.option__Option_u128_ @"0000000000000002_bcs_peel_option_u12_C6eBmktECftBLv"(ptr %call_arg_041)
+  store %struct.option__Option_u128_ %retval42, ptr %local_49, align 8
+  %3 = call i1 @move_rt_struct_cmp_eq(ptr @__move_rttydesc_option__Option_u128_, ptr %local_9, ptr %local_49)
+  store i1 %3, ptr %local_50, align 1
+  %cnd43 = load i1, ptr %local_50, align 1
+  br i1 %cnd43, label %bb_10, label %bb_9
+
+bb_10:                                            ; preds = %bb_8
+  br label %bb_11
+
+bb_9:                                             ; preds = %bb_8
+  store i64 0, ptr %local_51, align 8
+  %call_arg_044 = load i64, ptr %local_51, align 8
+  call void @move_rt_abort(i64 %call_arg_044)
+  unreachable
+
+bb_11:                                            ; preds = %bb_10
+  %4 = load [32 x i8], ptr @acct.addr.34, align 1
+  store [32 x i8] %4, ptr %local_52, align 1
+  %call_arg_045 = load [32 x i8], ptr %local_52, align 1
+  %retval46 = call %struct.option__Option_address_ @"0000000000000001_option_some_CDdPcTrWutT5hX"([32 x i8] %call_arg_045)
+  store %struct.option__Option_address_ %retval46, ptr %local_53, align 8
+  %load_store_tmp47 = load %struct.option__Option_address_, ptr %local_53, align 8
+  store %struct.option__Option_address_ %load_store_tmp47, ptr %local_10, align 8
+  store ptr %local_10, ptr %local_54, align 8
+  %call_arg_048 = load ptr, ptr %local_54, align 8
+  %retval49 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_F4VKBm8kUmngog"(ptr %call_arg_048)
+  store { ptr, i64, i64 } %retval49, ptr %local_55, align 8
+  %call_arg_050 = load { ptr, i64, i64 }, ptr %local_55, align 8
+  %retval51 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_050)
+  store %struct.bcs__BCS %retval51, ptr %local_56, align 8
+  %load_store_tmp52 = load %struct.bcs__BCS, ptr %local_56, align 8
+  store %struct.bcs__BCS %load_store_tmp52, ptr %local_4, align 8
+  store ptr %local_4, ptr %local_58, align 8
+  %call_arg_053 = load ptr, ptr %local_58, align 8
+  %retval54 = call %struct.option__Option_address_ @"0000000000000002_bcs_peel_option_add_3CPk1XLtV1YCnh"(ptr %call_arg_053)
+  store %struct.option__Option_address_ %retval54, ptr %local_59, align 8
+  %5 = call i1 @move_rt_struct_cmp_eq(ptr @__move_rttydesc_option__Option_address_, ptr %local_10, ptr %local_59)
+  store i1 %5, ptr %local_60, align 1
+  %cnd55 = load i1, ptr %local_60, align 1
+  br i1 %cnd55, label %bb_13, label %bb_12
+
+bb_13:                                            ; preds = %bb_11
+  br label %bb_14
+
+bb_12:                                            ; preds = %bb_11
+  store i64 0, ptr %local_61, align 8
+  %call_arg_056 = load i64, ptr %local_61, align 8
+  call void @move_rt_abort(i64 %call_arg_056)
+  unreachable
+
+bb_14:                                            ; preds = %bb_13
+  %retval57 = call %struct.option__Option_bool_ @"0000000000000001_option_none_HcJFTKMJvLKwdo"()
+  store %struct.option__Option_bool_ %retval57, ptr %local_62, align 8
+  %load_store_tmp58 = load %struct.option__Option_bool_, ptr %local_62, align 8
+  store %struct.option__Option_bool_ %load_store_tmp58, ptr %local_11, align 8
+  store ptr %local_11, ptr %local_63, align 8
+  %call_arg_059 = load ptr, ptr %local_63, align 8
+  %retval60 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_G6s6Uuxhs2JvCy"(ptr %call_arg_059)
+  store { ptr, i64, i64 } %retval60, ptr %local_64, align 8
+  %call_arg_061 = load { ptr, i64, i64 }, ptr %local_64, align 8
+  %retval62 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_061)
+  store %struct.bcs__BCS %retval62, ptr %local_65, align 8
+  %load_store_tmp63 = load %struct.bcs__BCS, ptr %local_65, align 8
+  store %struct.bcs__BCS %load_store_tmp63, ptr %local_5, align 8
+  store ptr %local_5, ptr %local_67, align 8
+  %call_arg_064 = load ptr, ptr %local_67, align 8
+  %retval65 = call %struct.option__Option_bool_ @"0000000000000002_bcs_peel_option_boo_4RJsKiXKvzRAXW"(ptr %call_arg_064)
+  store %struct.option__Option_bool_ %retval65, ptr %local_68, align 8
+  %6 = call i1 @move_rt_struct_cmp_eq(ptr @__move_rttydesc_option__Option_bool_, ptr %local_11, ptr %local_68)
+  store i1 %6, ptr %local_69, align 1
+  %cnd66 = load i1, ptr %local_69, align 1
+  br i1 %cnd66, label %bb_16, label %bb_15
+
+bb_16:                                            ; preds = %bb_14
+  br label %bb_17
+
+bb_15:                                            ; preds = %bb_14
+  store i64 0, ptr %local_70, align 8
+  %call_arg_067 = load i64, ptr %local_70, align 8
+  call void @move_rt_abort(i64 %call_arg_067)
+  unreachable
+
+bb_17:                                            ; preds = %bb_16
+  ret void
+}
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_G6s6Uuxhs2JvCy"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_option__Option_bool_, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_34VWcXYqydUD6L"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_option__Option_u8_, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_6tpUBfguzJhbz8"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_option__Option_u64_, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_42cyBZkxm74pJ6"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_option__Option_u128_, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_F4VKBm8kUmngog"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_option__Option_address_, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+define private void @"0000000000000002_bcs_test_uleb_len_f_6tBQk9xLoTiiHV"() {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca %struct.bcs__BCS, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca { ptr, i64, i64 }, align 8
+  %local_5 = alloca %struct.bcs__BCS, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i64, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u64)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u64, ptr %newv, ptr @vdesc.37)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_2, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_2, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_3, align 8
+  %call_arg_0 = load ptr, ptr %local_3, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_5WzzmfEmjB8Pdw"(ptr %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_4, align 8
+  %call_arg_01 = load { ptr, i64, i64 }, ptr %local_4, align 8
+  %retval2 = call %struct.bcs__BCS @"0000000000000002_bcs_new_FBTBR4geaEnK8K"({ ptr, i64, i64 } %call_arg_01)
+  store %struct.bcs__BCS %retval2, ptr %local_5, align 8
+  %load_store_tmp3 = load %struct.bcs__BCS, ptr %local_5, align 8
+  store %struct.bcs__BCS %load_store_tmp3, ptr %local_0, align 8
+  store ptr %local_0, ptr %local_6, align 8
+  %call_arg_04 = load ptr, ptr %local_6, align 8
+  %retval5 = call i64 @"0000000000000002_bcs_peel_vec_length_HNqBjL6pYANzcQ"(ptr %call_arg_04)
+  store i64 %retval5, ptr %local_7, align 8
+  store i64 2, ptr %local_8, align 8
+  %call_arg_06 = load i64, ptr %local_8, align 8
+  call void @move_rt_abort(i64 %call_arg_06)
+  unreachable
+}
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)
+
+; Function Attrs: cold noreturn
+declare void @move_rt_abort(i64) #0
+
+declare { ptr, i64, i64 } @move_rt_vec_empty(ptr nonnull readonly dereferenceable(32))
+
+declare void @move_rt_vec_copy(ptr nonnull readonly dereferenceable(32), ptr nonnull dereferenceable(24), ptr nonnull readonly dereferenceable(24))
+
+declare i1 @move_rt_vec_cmp_eq(ptr nonnull readonly dereferenceable(32), ptr nonnull readonly dereferenceable(24), ptr nonnull readonly dereferenceable(24))
+
+declare i1 @move_rt_struct_cmp_eq(ptr nonnull readonly dereferenceable(32), ptr nonnull readonly, ptr nonnull readonly)
+
+attributes #0 = { cold noreturn }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__bls12381.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__bls12381.ll.expected
@@ -1,0 +1,2768 @@
+; ModuleID = '0x2__bls12381'
+source_filename = "../../../../../../../crates/sui-framework/packages/sui-framework/sources/crypto/bls12381.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+%struct.group_ops__Element_bls12381__GT_ = type { { ptr, i64, i64 } }
+%struct.group_ops__Element_bls12381__G1_ = type { { ptr, i64, i64 } }
+%struct.group_ops__Element_bls12381__G2_ = type { { ptr, i64, i64 } }
+%struct.group_ops__Element_bls12381__Scalar_ = type { { ptr, i64, i64 } }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+@vec_literal = internal constant [48 x i8] c"\97\F1\D3\A71\97\D7\94&\95c\8CO\A9\AC\0F\C3h\8CO\97t\B9\05\A1N:?\17\1B\ACXlU\E8?\F9z\1A\EF\FB:\F0\0A\DB\22\C6\BB"
+@vdesc = internal constant { ptr, i64, i64 } { ptr @vec_literal, i64 48, i64 48 }
+@__move_rttydesc_u8 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u8_name, i64 2 }, i64 2, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u8_name = private unnamed_addr constant [2 x i8] c"u8"
+@vec_literal.1 = internal constant [48 x i8] c"\C0\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+@vdesc.2 = internal constant { ptr, i64, i64 } { ptr @vec_literal.1, i64 48, i64 48 }
+@__move_rttydesc_group_ops__Element_bls12381__Scalar_ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_group_ops__Element_bls12381__Scalar__name, i64 168 }, i64 11, ptr @__move_rttydesc_group_ops__Element_bls12381__Scalar__info }
+@__move_rttydesc_group_ops__Element_bls12381__Scalar__name = private unnamed_addr constant [168 x i8] c"0000000000000000000000000000000000000000000000000000000000000002::group_ops::Element<0000000000000000000000000000000000000000000000000000000000000002::bls12381::Scalar>"
+@__move_rttydesc_vector_u8__name = private unnamed_addr constant [10 x i8] c"vector<u8>"
+@__move_rttydesc_vector_u8__info = private unnamed_addr constant { ptr } { ptr @__move_rttydesc_u8 }
+@0 = private unnamed_addr constant [5 x i8] c"bytes"
+@s_fld_array = private unnamed_addr constant [1 x { %__move_rt_type, i64, { ptr, i64 } }] [{ %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_u8__name, i64 10 }, i64 10, ptr @__move_rttydesc_vector_u8__info }, i64 0, { ptr, i64 } { ptr @0, i64 5 } }]
+@__move_rttydesc_group_ops__Element_bls12381__Scalar__info = private unnamed_addr constant { ptr, i64, i64, i64 } { ptr @s_fld_array, i64 1, i64 24, i64 8 }
+@__move_rttydesc_group_ops__Element_bls12381__G1_ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_group_ops__Element_bls12381__G1__name, i64 164 }, i64 11, ptr @__move_rttydesc_group_ops__Element_bls12381__G1__info }
+@__move_rttydesc_group_ops__Element_bls12381__G1__name = private unnamed_addr constant [164 x i8] c"0000000000000000000000000000000000000000000000000000000000000002::group_ops::Element<0000000000000000000000000000000000000000000000000000000000000002::bls12381::G1>"
+@1 = private unnamed_addr constant [5 x i8] c"bytes"
+@s_fld_array.3 = private unnamed_addr constant [1 x { %__move_rt_type, i64, { ptr, i64 } }] [{ %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_u8__name, i64 10 }, i64 10, ptr @__move_rttydesc_vector_u8__info }, i64 0, { ptr, i64 } { ptr @1, i64 5 } }]
+@__move_rttydesc_group_ops__Element_bls12381__G1__info = private unnamed_addr constant { ptr, i64, i64, i64 } { ptr @s_fld_array.3, i64 1, i64 24, i64 8 }
+@vec_literal.4 = internal constant [96 x i8] c"\93\E0+`Rq\9F`}\AC\D3\A0\88'OeYk\D0\D0\99 \B6\1A\B5\DAa\BB\DC\7FPI3L\F1\12\13\94]W\E5\AC}\05]\04+~\02J\A2\B2\F0\8F\0A\91&\08\05'-\C5\10Q\C6\E4z\D4\FA@;\02\B4Q\0Bdz\E3\D1w\0B\AC\03&\A8\05\BB\EF\D4\80V\C8\C1!\BD\B8"
+@vdesc.5 = internal constant { ptr, i64, i64 } { ptr @vec_literal.4, i64 96, i64 96 }
+@vec_literal.6 = internal constant [96 x i8] c"\C0\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+@vdesc.7 = internal constant { ptr, i64, i64 } { ptr @vec_literal.6, i64 96, i64 96 }
+@__move_rttydesc_group_ops__Element_bls12381__G2_ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_group_ops__Element_bls12381__G2__name, i64 164 }, i64 11, ptr @__move_rttydesc_group_ops__Element_bls12381__G2__info }
+@__move_rttydesc_group_ops__Element_bls12381__G2__name = private unnamed_addr constant [164 x i8] c"0000000000000000000000000000000000000000000000000000000000000002::group_ops::Element<0000000000000000000000000000000000000000000000000000000000000002::bls12381::G2>"
+@2 = private unnamed_addr constant [5 x i8] c"bytes"
+@s_fld_array.8 = private unnamed_addr constant [1 x { %__move_rt_type, i64, { ptr, i64 } }] [{ %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_u8__name, i64 10 }, i64 10, ptr @__move_rttydesc_vector_u8__info }, i64 0, { ptr, i64 } { ptr @2, i64 5 } }]
+@__move_rttydesc_group_ops__Element_bls12381__G2__info = private unnamed_addr constant { ptr, i64, i64, i64 } { ptr @s_fld_array.8, i64 1, i64 24, i64 8 }
+@vec_literal.9 = internal constant [576 x i8] c"\12P\EB\D8q\FC\0A\92\A7\B2\D81h\D0\D7''-D\1B\EF\A1\\P=\D8\E9\0C\E9\8D\B3\E7\B6\D1\94\F6\089\C5\08\A8C\05\AA\CA\17\89\B6\08\9A\1C[F\E5\11\0B\86u\0E\C6\A524\88h\A8@EH<\92\B7\AFZ\F6\89E.\AF\AB\F1\A8\94>PC\9F\1DY\88*\98\EA\A0\17\0F\19\F2c7\D2\05\FBF\9C\D6\BD\15\C3\D5\A0M\C8\87\84\FB\B3\D0\B2\DB\DE\A5MC\B2\B7?,\BB\12\D5\83\86\A8p>\0F\94\82&\E4~\E8\9D\06\FB\A2>\B7\C5\AF\0D\9F\80\94\0C\A7q\B6\FF\D5\85{\AA\F2\22\EB\95\A7\D2\80\9Da\BF\E0.\1B\FD\1Bh\FF\02\F0\B8\10*\E1\C2\D5\D5\AB\1A\13h\BBD\\|- \97\03\F29h\9C\E3L\03x\A6\8Er\A6\B3\B2\16\DA\0E\22\A5\03\1BT\DD\FFW0\93\96\B3\8C\88\1CL\84\9E\C2>\87\195\02\B8n\DB\88W\C2s\FA\07ZPQ)7\E0yN\1Ee\A7a|\90\D8\BDf\06[\1F\FF\E5\1DzW\99s\B11P!\EC<\19\93O\11\B8\B4$\CDH\BF8\FC\EFh\08;\0B\0E\C5\C8\1A\93\B30\EE\1Ag}\0D\15\FF{\98N\89x\EFH\88\1E2\FA\C9\1B\93\B4s3\E2\BAW\035\0FU\A7\AE\FC\D3\C3\1BO\CBl\E5w\1C\C6\A0\E9xj\B5\973 \C8\06\AD6\08)\10{\A8\10\C5\A0\9F\FD\D9\BE\22\91\A0\C2Z\99\A2\01\B2\F5\22G=\17\13\91\12[\A8M\C4\00|\FB\F2\F8\DAu/|t\18R\03\FC\CAX\9A\C7\19\C3M\FF\BB\AA\D8C\1D\AD\1C\1F\B5\97\AA\A5\01\81\07\15O%\A7d\BD<y\93zE\B8EF\DAcK\8Fk\E1J\80a\E5\\\CE\BAG\8B#\F7\DA\CA\A3\\\8C\A7\8B\EA\E9b@E\B4\B6\04\C5\81#M\08j\99\02$\9Bdr\8F\FD!\A1\89\E8y5\A9T\05\1C|\DB\A7\B3\87&)\A4\FA\FC\05\06bE\CB\91\08\F0$-\0F\E3\EF\0FA\E5\86c\BF\08\CF\06\86r\CB\D0\1A~\C7;\AC\A4\D7,\A95D\DE\FFhk\FDm\F5C\D4\8E\AA$\AF\E4~\1E\FD\E4I8;gf1"
+@vdesc.10 = internal constant { ptr, i64, i64 } { ptr @vec_literal.9, i64 576, i64 576 }
+@vec_literal.11 = internal constant [576 x i8] c"\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+@vdesc.12 = internal constant { ptr, i64, i64 } { ptr @vec_literal.11, i64 576, i64 576 }
+@vec_literal.13 = internal constant [32 x i8] zeroinitializer
+@vdesc.14 = internal constant { ptr, i64, i64 } { ptr @vec_literal.13, i64 32, i64 32 }
+@vec_literal.15 = internal constant [32 x i8] c"\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01"
+@vdesc.16 = internal constant { ptr, i64, i64 } { ptr @vec_literal.15, i64 32, i64 32 }
+@vec_literal.17 = internal constant [32 x i8] zeroinitializer
+@vdesc.18 = internal constant { ptr, i64, i64 } { ptr @vec_literal.17, i64 32, i64 32 }
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define void @"0000000000000002_bls12381_unit_test_poiso_8NUmc3Uj4SYtWa"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+define %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_bls12381_pairing_4TrYMFtVLJPMkv"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 1, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_group_ops_pairing_4Uvhw9WszKUYn4"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__GT_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__GT_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__GT_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_group_ops_pairing_4Uvhw9WszKUYn4"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__G1_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__G2_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_pairing(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__GT_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__GT_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__GT_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__GT_ %retval7
+}
+
+declare { ptr, i64, i64 } @move_native_group_ops_internal_pairing(i8, ptr, ptr)
+
+declare i1 @move_native_bls12381_bls12381_min_pk_verify(ptr, ptr, ptr)
+
+declare i1 @move_native_bls12381_bls12381_min_sig_verify(ptr, ptr, ptr)
+
+define %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_bls12381_g1_add_CkR6SM7BuRnuMj"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 1, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_add_5FDhgkSAfeNzNH"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G1_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_add_5FDhgkSAfeNzNH"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__G1_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__G1_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_add(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__G1_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__G1_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval7
+}
+
+declare { ptr, i64, i64 } @move_native_group_ops_internal_add(i8, ptr, ptr)
+
+define %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_bls12381_g1_div_3V4GcgPydbpFkQ"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 1, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_div_7Y6ZZjGePtg1tB"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G1_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_div_7Y6ZZjGePtg1tB"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__G1_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_div(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__G1_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__G1_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval7
+}
+
+declare { ptr, i64, i64 } @move_native_group_ops_internal_div(i8, ptr, ptr)
+
+define %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_bls12381_g1_from_bytes_cgzwVQqnmW1wY7"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store i8 1, ptr %local_1, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_2, align 8
+  store i1 false, ptr %local_3, align 1
+  %call_arg_0 = load i8, ptr %local_1, align 1
+  %call_arg_1 = load ptr, ptr %local_2, align 8
+  %call_arg_2 = load i1, ptr %local_3, align 1
+  %retval = call %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_from_bytes_8nysSJmWy4dU8W"(i8 %call_arg_0, ptr %call_arg_1, i1 %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G1_ %retval, ptr %local_4, align 8
+  %retval1 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_4, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval1
+}
+
+define private %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_from_bytes_8nysSJmWy4dU8W"(i8 %0, ptr nonnull readonly %1, i1 %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i1, align 1
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca i1, align 1
+  %local_6 = alloca i8, align 1
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca i1, align 1
+  %local_10 = alloca ptr, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca ptr, align 8
+  %local_13__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_14 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store i1 %2, ptr %local_2, align 1
+  %load_store_tmp = load i1, ptr %local_2, align 1
+  store i1 %load_store_tmp, ptr %local_4, align 1
+  %cnd = load i1, ptr %local_4, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  store i1 true, ptr %local_5, align 1
+  %load_store_tmp1 = load i1, ptr %local_5, align 1
+  store i1 %load_store_tmp1, ptr %local_3, align 1
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp2 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp2, ptr %local_6, align 1
+  %load_store_tmp3 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp3, ptr %local_7, align 8
+  %loaded_alloca = load i8, ptr %local_6, align 1
+  %loaded_alloca4 = load ptr, ptr %local_7, align 8
+  %retval = call i1 @move_native_group_ops_internal_validate(i8 %loaded_alloca, ptr %loaded_alloca4)
+  store i1 %retval, ptr %local_8, align 1
+  %load_store_tmp5 = load i1, ptr %local_8, align 1
+  store i1 %load_store_tmp5, ptr %local_3, align 1
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_0, %bb_1
+  %load_store_tmp6 = load i1, ptr %local_3, align 1
+  store i1 %load_store_tmp6, ptr %local_9, align 1
+  %cnd7 = load i1, ptr %local_9, align 1
+  br i1 %cnd7, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  %load_store_tmp8 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp8, ptr %local_10, align 8
+  store i64 1, ptr %local_11, align 8
+  %call_arg_0 = load i64, ptr %local_11, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_5:                                             ; preds = %bb_4
+  %load_store_tmp9 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp9, ptr %local_12, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_12, align 8
+  %load_deref_store_tmp2 = load { ptr, i64, i64 }, ptr %load_deref_store_tmp1, align 8
+  store { ptr, i64, i64 } %load_deref_store_tmp2, ptr %local_13__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_13__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__G1_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__G1_ %insert_0, ptr %local_14, align 8
+  %retval10 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_14, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval10
+}
+
+declare i1 @move_native_group_ops_internal_validate(i8, ptr)
+
+define %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_bls12381_g1_generator_DXcZUc6LuJg6gX"() {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_1, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_0, align 8
+  store i8 1, ptr %local_2, align 1
+  store ptr %local_0, ptr %local_3, align 8
+  store i1 true, ptr %local_4, align 1
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load i1, ptr %local_4, align 1
+  %retval = call %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_from_bytes_8nysSJmWy4dU8W"(i8 %call_arg_0, ptr %call_arg_1, i1 %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G1_ %retval, ptr %local_5, align 8
+  %retval1 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval1
+}
+
+define %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_bls12381_g1_identity_HC8zzhiRBbkvyU"() {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.2)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_1, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_0, align 8
+  store i8 1, ptr %local_2, align 1
+  store ptr %local_0, ptr %local_3, align 8
+  store i1 true, ptr %local_4, align 1
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load i1, ptr %local_4, align 1
+  %retval = call %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_from_bytes_8nysSJmWy4dU8W"(i8 %call_arg_0, ptr %call_arg_1, i1 %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G1_ %retval, ptr %local_5, align 8
+  %retval1 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval1
+}
+
+define %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_bls12381_g1_mul_6pRZHwJrsbzzhi"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 1, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_mul_Ggozy62bH2MW91"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G1_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_mul_Ggozy62bH2MW91"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__G1_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_mul(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__G1_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__G1_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval7
+}
+
+declare { ptr, i64, i64 } @move_native_group_ops_internal_mul(i8, ptr, ptr)
+
+define %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_bls12381_g1_multi_scalar_FYs2vj4sa1hQKe"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 1, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_multi_scalar_mu_H3STcG9t8Ns3jZ"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G1_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_multi_scalar_mu_H3STcG9t8Ns3jZ"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  %local_4 = alloca { ptr, i64, i64 }, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  %local_7 = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca ptr, align 8
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca i64, align 8
+  %local_11 = alloca i1, align 1
+  %local_12 = alloca ptr, align 8
+  %local_13 = alloca ptr, align 8
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca ptr, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca ptr, align 8
+  %local_18 = alloca i64, align 8
+  %local_19 = alloca i1, align 1
+  %local_20 = alloca ptr, align 8
+  %local_21 = alloca ptr, align 8
+  %local_22 = alloca i64, align 8
+  %local_23 = alloca { ptr, i64, i64 }, align 8
+  %local_24 = alloca { ptr, i64, i64 }, align 8
+  %local_25 = alloca i64, align 8
+  %local_26 = alloca i64, align 8
+  %local_27 = alloca ptr, align 8
+  %local_28 = alloca i64, align 8
+  %local_29 = alloca i1, align 1
+  %local_30 = alloca ptr, align 8
+  %local_31 = alloca i64, align 8
+  %local_32 = alloca ptr, align 8
+  %local_33 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  %local_34 = alloca ptr, align 8
+  %local_35 = alloca ptr, align 8
+  %local_36__bytes = alloca ptr, align 8
+  %local_37 = alloca { ptr, i64, i64 }, align 8
+  %local_38 = alloca ptr, align 8
+  %local_39 = alloca i64, align 8
+  %local_40 = alloca ptr, align 8
+  %local_41 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  %local_42 = alloca ptr, align 8
+  %local_43 = alloca ptr, align 8
+  %local_44__bytes = alloca ptr, align 8
+  %local_45 = alloca { ptr, i64, i64 }, align 8
+  %local_46 = alloca i64, align 8
+  %local_47 = alloca i64, align 8
+  %local_48 = alloca i64, align 8
+  %local_49 = alloca ptr, align 8
+  %local_50 = alloca ptr, align 8
+  %local_51 = alloca i8, align 1
+  %local_52 = alloca ptr, align 8
+  %local_53 = alloca ptr, align 8
+  %local_54__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_55 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp, ptr %local_8, align 8
+  %loaded_alloca = load ptr, ptr %local_8, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_group_ops__Element_bls12381__Scalar_, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_9, align 8
+  store i64 0, ptr %local_10, align 8
+  %gt_src_0 = load i64, ptr %local_9, align 8
+  %gt_src_1 = load i64, ptr %local_10, align 8
+  %gt_dst = icmp ugt i64 %gt_src_0, %gt_src_1
+  store i1 %gt_dst, ptr %local_11, align 1
+  %cnd = load i1, ptr %local_11, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_12, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_13, align 8
+  store i64 1, ptr %local_14, align 8
+  %call_arg_0 = load i64, ptr %local_14, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  %load_store_tmp3 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp3, ptr %local_15, align 8
+  %loaded_alloca4 = load ptr, ptr %local_15, align 8
+  %retval5 = call i64 @move_native_vector_length(ptr @__move_rttydesc_group_ops__Element_bls12381__Scalar_, ptr %loaded_alloca4)
+  store i64 %retval5, ptr %local_16, align 8
+  %load_store_tmp6 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp6, ptr %local_17, align 8
+  %loaded_alloca7 = load ptr, ptr %local_17, align 8
+  %retval8 = call i64 @move_native_vector_length(ptr @__move_rttydesc_group_ops__Element_bls12381__G1_, ptr %loaded_alloca7)
+  store i64 %retval8, ptr %local_18, align 8
+  %eq_src_0 = load i64, ptr %local_16, align 8
+  %eq_src_1 = load i64, ptr %local_18, align 8
+  %eq_dst = icmp eq i64 %eq_src_0, %eq_src_1
+  store i1 %eq_dst, ptr %local_19, align 1
+  %cnd9 = load i1, ptr %local_19, align 1
+  br i1 %cnd9, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  %load_store_tmp10 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp10, ptr %local_20, align 8
+  %load_store_tmp11 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp11, ptr %local_21, align 8
+  store i64 1, ptr %local_22, align 8
+  %call_arg_012 = load i64, ptr %local_22, align 8
+  call void @move_rt_abort(i64 %call_arg_012)
+  unreachable
+
+bb_5:                                             ; preds = %bb_4
+  %retval13 = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %retval13, ptr %local_23, align 8
+  %load_store_tmp14 = load { ptr, i64, i64 }, ptr %local_23, align 8
+  store { ptr, i64, i64 } %load_store_tmp14, ptr %local_7, align 8
+  %retval15 = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %retval15, ptr %local_24, align 8
+  %load_store_tmp16 = load { ptr, i64, i64 }, ptr %local_24, align 8
+  store { ptr, i64, i64 } %load_store_tmp16, ptr %local_4, align 8
+  store i64 0, ptr %local_25, align 8
+  %load_store_tmp17 = load i64, ptr %local_25, align 8
+  store i64 %load_store_tmp17, ptr %local_5, align 8
+  br label %bb_9
+
+bb_9:                                             ; preds = %join_bb, %bb_5
+  %load_store_tmp18 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp18, ptr %local_26, align 8
+  %load_store_tmp19 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp19, ptr %local_27, align 8
+  %loaded_alloca20 = load ptr, ptr %local_27, align 8
+  %retval21 = call i64 @move_native_vector_length(ptr @__move_rttydesc_group_ops__Element_bls12381__Scalar_, ptr %loaded_alloca20)
+  store i64 %retval21, ptr %local_28, align 8
+  %lt_src_0 = load i64, ptr %local_26, align 8
+  %lt_src_1 = load i64, ptr %local_28, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_29, align 1
+  %cnd22 = load i1, ptr %local_29, align 1
+  br i1 %cnd22, label %bb_7, label %bb_6
+
+bb_7:                                             ; preds = %bb_9
+  br label %bb_8
+
+bb_8:                                             ; preds = %bb_7
+  %load_store_tmp23 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp23, ptr %local_30, align 8
+  %load_store_tmp24 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp24, ptr %local_31, align 8
+  %loaded_alloca25 = load ptr, ptr %local_30, align 8
+  %loaded_alloca26 = load i64, ptr %local_31, align 8
+  %retval27 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_group_ops__Element_bls12381__Scalar_, ptr %loaded_alloca25, i64 %loaded_alloca26)
+  store ptr %retval27, ptr %local_32, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_32, align 8
+  %load_deref_store_tmp2 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %load_deref_store_tmp1, align 8
+  store %struct.group_ops__Element_bls12381__Scalar_ %load_deref_store_tmp2, ptr %local_33, align 8
+  %load_store_tmp28 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_33, align 8
+  store %struct.group_ops__Element_bls12381__Scalar_ %load_store_tmp28, ptr %local_6, align 8
+  store ptr %local_7, ptr %local_34, align 8
+  store ptr %local_6, ptr %local_35, align 8
+  %tmp = load ptr, ptr %local_35, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_36__bytes, align 8
+  %load_deref_store_tmp129 = load ptr, ptr %local_36__bytes, align 8
+  %load_deref_store_tmp230 = load { ptr, i64, i64 }, ptr %load_deref_store_tmp129, align 8
+  store { ptr, i64, i64 } %load_deref_store_tmp230, ptr %local_37, align 8
+  %call_arg_031 = load ptr, ptr %local_34, align 8
+  %call_arg_1 = load { ptr, i64, i64 }, ptr %local_37, align 8
+  call void @"0000000000000001_vector_append_9dqoPGavEhpvk5"(ptr %call_arg_031, { ptr, i64, i64 } %call_arg_1)
+  %load_store_tmp32 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp32, ptr %local_38, align 8
+  %load_store_tmp33 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp33, ptr %local_39, align 8
+  %loaded_alloca34 = load ptr, ptr %local_38, align 8
+  %loaded_alloca35 = load i64, ptr %local_39, align 8
+  %retval36 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_group_ops__Element_bls12381__G1_, ptr %loaded_alloca34, i64 %loaded_alloca35)
+  store ptr %retval36, ptr %local_40, align 8
+  %load_deref_store_tmp137 = load ptr, ptr %local_40, align 8
+  %load_deref_store_tmp238 = load %struct.group_ops__Element_bls12381__G1_, ptr %load_deref_store_tmp137, align 8
+  store %struct.group_ops__Element_bls12381__G1_ %load_deref_store_tmp238, ptr %local_41, align 8
+  %load_store_tmp39 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_41, align 8
+  store %struct.group_ops__Element_bls12381__G1_ %load_store_tmp39, ptr %local_3, align 8
+  store ptr %local_4, ptr %local_42, align 8
+  store ptr %local_3, ptr %local_43, align 8
+  %tmp40 = load ptr, ptr %local_43, align 8
+  %fld_ref41 = getelementptr inbounds %struct.group_ops__Element_bls12381__G1_, ptr %tmp40, i32 0, i32 0
+  store ptr %fld_ref41, ptr %local_44__bytes, align 8
+  %load_deref_store_tmp142 = load ptr, ptr %local_44__bytes, align 8
+  %load_deref_store_tmp243 = load { ptr, i64, i64 }, ptr %load_deref_store_tmp142, align 8
+  store { ptr, i64, i64 } %load_deref_store_tmp243, ptr %local_45, align 8
+  %call_arg_044 = load ptr, ptr %local_42, align 8
+  %call_arg_145 = load { ptr, i64, i64 }, ptr %local_45, align 8
+  call void @"0000000000000001_vector_append_9dqoPGavEhpvk5"(ptr %call_arg_044, { ptr, i64, i64 } %call_arg_145)
+  %load_store_tmp46 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp46, ptr %local_46, align 8
+  store i64 1, ptr %local_47, align 8
+  %add_src_0 = load i64, ptr %local_46, align 8
+  %add_src_1 = load i64, ptr %local_47, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_8
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_8
+  store i64 %add_dst, ptr %local_48, align 8
+  %load_store_tmp47 = load i64, ptr %local_48, align 8
+  store i64 %load_store_tmp47, ptr %local_5, align 8
+  br label %bb_9
+
+bb_6:                                             ; preds = %bb_9
+  %load_store_tmp48 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp48, ptr %local_49, align 8
+  %load_store_tmp49 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp49, ptr %local_50, align 8
+  %load_store_tmp50 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp50, ptr %local_51, align 1
+  store ptr %local_7, ptr %local_52, align 8
+  store ptr %local_4, ptr %local_53, align 8
+  %loaded_alloca51 = load i8, ptr %local_51, align 1
+  %loaded_alloca52 = load ptr, ptr %local_52, align 8
+  %loaded_alloca53 = load ptr, ptr %local_53, align 8
+  %retval54 = call { ptr, i64, i64 } @move_native_group_ops_internal_multi_scalar_mul(i8 %loaded_alloca51, ptr %loaded_alloca52, ptr %loaded_alloca53)
+  store { ptr, i64, i64 } %retval54, ptr %local_54__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_54__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__G1_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__G1_ %insert_0, ptr %local_55, align 8
+  %retval55 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_55, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval55
+}
+
+declare i64 @move_native_vector_length(ptr, ptr)
+
+declare { ptr, i64, i64 } @move_native_vector_empty(ptr)
+
+declare ptr @move_native_vector_borrow(ptr, ptr, i64)
+
+define private void @"0000000000000001_vector_append_9dqoPGavEhpvk5"(ptr noalias nonnull %0, { ptr, i64, i64 } %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca i1, align 1
+  %local_6 = alloca ptr, align 8
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca i8, align 1
+  %local_9 = alloca ptr, align 8
+  %local_10 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  store { ptr, i64, i64 } %1, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_2, align 8
+  %call_arg_0 = load ptr, ptr %local_2, align 8
+  call void @"0000000000000001_vector_reverse_DYV9motnmmM5cs"(ptr %call_arg_0)
+  br label %bb_3
+
+bb_3:                                             ; preds = %bb_2, %entry
+  store ptr %local_1, ptr %local_3, align 8
+  %call_arg_01 = load ptr, ptr %local_3, align 8
+  %retval = call i1 @"0000000000000001_vector_is_empty_BrzErKu8hVV1SC"(ptr %call_arg_01)
+  store i1 %retval, ptr %local_4, align 1
+  %not_src = load i1, ptr %local_4, align 1
+  %not_dst = xor i1 %not_src, true
+  store i1 %not_dst, ptr %local_5, align 1
+  %cnd = load i1, ptr %local_5, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %bb_3
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_6, align 8
+  store ptr %local_1, ptr %local_7, align 8
+  %loaded_alloca = load ptr, ptr %local_7, align 8
+  call void @move_native_vector_pop_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca, ptr %local_8)
+  %loaded_alloca2 = load ptr, ptr %local_6, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca2, ptr %local_8)
+  br label %bb_3
+
+bb_0:                                             ; preds = %bb_3
+  %load_store_tmp3 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp3, ptr %local_9, align 8
+  %load_store_tmp4 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp4, ptr %local_10, align 8
+  call void @move_native_vector_destroy_empty(ptr @__move_rttydesc_u8, ptr %local_10)
+  ret void
+}
+
+define private void @"0000000000000001_vector_reverse_DYV9motnmmM5cs"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca ptr, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i1, align 1
+  %local_10 = alloca ptr, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca i64, align 8
+  %local_13 = alloca i64, align 8
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca i1, align 1
+  %local_18 = alloca ptr, align 8
+  %local_19 = alloca i64, align 8
+  %local_20 = alloca i64, align 8
+  %local_21 = alloca i64, align 8
+  %local_22 = alloca i64, align 8
+  %local_23 = alloca i64, align 8
+  %local_24 = alloca i64, align 8
+  %local_25 = alloca i64, align 8
+  %local_26 = alloca i64, align 8
+  %local_27 = alloca ptr, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_4, align 8
+  %load_store_tmp1 = load ptr, ptr %local_4, align 8
+  store ptr %load_store_tmp1, ptr %local_5, align 8
+  %loaded_alloca = load ptr, ptr %local_5, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_6, align 8
+  %load_store_tmp2 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp2, ptr %local_3, align 8
+  %load_store_tmp3 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp3, ptr %local_7, align 8
+  store i64 0, ptr %local_8, align 8
+  %eq_src_0 = load i64, ptr %local_7, align 8
+  %eq_src_1 = load i64, ptr %local_8, align 8
+  %eq_dst = icmp eq i64 %eq_src_0, %eq_src_1
+  store i1 %eq_dst, ptr %local_9, align 1
+  %cnd = load i1, ptr %local_9, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  %load_store_tmp4 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp4, ptr %local_10, align 8
+  ret void
+
+bb_0:                                             ; preds = %entry
+  store i64 0, ptr %local_11, align 8
+  %load_store_tmp5 = load i64, ptr %local_11, align 8
+  store i64 %load_store_tmp5, ptr %local_2, align 8
+  %load_store_tmp6 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp6, ptr %local_12, align 8
+  store i64 1, ptr %local_13, align 8
+  %sub_src_0 = load i64, ptr %local_12, align 8
+  %sub_src_1 = load i64, ptr %local_13, align 8
+  %sub_dst = sub i64 %sub_src_0, %sub_src_1
+  %ovfcond = icmp ugt i64 %sub_dst, %sub_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_0
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_0
+  store i64 %sub_dst, ptr %local_14, align 8
+  %load_store_tmp7 = load i64, ptr %local_14, align 8
+  store i64 %load_store_tmp7, ptr %local_1, align 8
+  br label %bb_5
+
+bb_5:                                             ; preds = %join_bb28, %join_bb
+  %load_store_tmp8 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp8, ptr %local_15, align 8
+  %load_store_tmp9 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp9, ptr %local_16, align 8
+  %lt_src_0 = load i64, ptr %local_15, align 8
+  %lt_src_1 = load i64, ptr %local_16, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_17, align 1
+  %cnd10 = load i1, ptr %local_17, align 1
+  br i1 %cnd10, label %bb_3, label %bb_2
+
+bb_3:                                             ; preds = %bb_5
+  br label %bb_4
+
+bb_4:                                             ; preds = %bb_3
+  %load_store_tmp11 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp11, ptr %local_18, align 8
+  %load_store_tmp12 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp12, ptr %local_19, align 8
+  %load_store_tmp13 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp13, ptr %local_20, align 8
+  %loaded_alloca14 = load ptr, ptr %local_18, align 8
+  %loaded_alloca15 = load i64, ptr %local_19, align 8
+  %loaded_alloca16 = load i64, ptr %local_20, align 8
+  call void @move_native_vector_swap(ptr @__move_rttydesc_u8, ptr %loaded_alloca14, i64 %loaded_alloca15, i64 %loaded_alloca16)
+  %load_store_tmp17 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp17, ptr %local_21, align 8
+  store i64 1, ptr %local_22, align 8
+  %add_src_0 = load i64, ptr %local_21, align 8
+  %add_src_1 = load i64, ptr %local_22, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond18 = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond18, label %then_bb19, label %join_bb20
+
+then_bb19:                                        ; preds = %bb_4
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb20:                                        ; preds = %bb_4
+  store i64 %add_dst, ptr %local_23, align 8
+  %load_store_tmp21 = load i64, ptr %local_23, align 8
+  store i64 %load_store_tmp21, ptr %local_2, align 8
+  %load_store_tmp22 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp22, ptr %local_24, align 8
+  store i64 1, ptr %local_25, align 8
+  %sub_src_023 = load i64, ptr %local_24, align 8
+  %sub_src_124 = load i64, ptr %local_25, align 8
+  %sub_dst25 = sub i64 %sub_src_023, %sub_src_124
+  %ovfcond26 = icmp ugt i64 %sub_dst25, %sub_src_023
+  br i1 %ovfcond26, label %then_bb27, label %join_bb28
+
+then_bb27:                                        ; preds = %join_bb20
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb28:                                        ; preds = %join_bb20
+  store i64 %sub_dst25, ptr %local_26, align 8
+  %load_store_tmp29 = load i64, ptr %local_26, align 8
+  store i64 %load_store_tmp29, ptr %local_1, align 8
+  br label %bb_5
+
+bb_2:                                             ; preds = %bb_5
+  %load_store_tmp30 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp30, ptr %local_27, align 8
+  ret void
+}
+
+declare void @move_native_vector_swap(ptr, ptr, i64, i64)
+
+define private i1 @"0000000000000001_vector_is_empty_BrzErKu8hVV1SC"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca i1, align 1
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_2, align 8
+  store i64 0, ptr %local_3, align 8
+  %eq_src_0 = load i64, ptr %local_2, align 8
+  %eq_src_1 = load i64, ptr %local_3, align 8
+  %eq_dst = icmp eq i64 %eq_src_0, %eq_src_1
+  store i1 %eq_dst, ptr %local_4, align 1
+  %retval1 = load i1, ptr %local_4, align 1
+  ret i1 %retval1
+}
+
+declare void @move_native_vector_pop_back(ptr, ptr, ptr)
+
+declare void @move_native_vector_push_back(ptr, ptr, ptr)
+
+declare void @move_native_vector_destroy_empty(ptr, ptr)
+
+declare { ptr, i64, i64 } @move_native_group_ops_internal_multi_scalar_mul(i8, ptr, ptr)
+
+define %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_bls12381_g1_neg_6hN9ttPdR8YegC"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  %local_2 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  store ptr %0, ptr %local_0, align 8
+  %retval = call %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_bls12381_g1_identity_HC8zzhiRBbkvyU"()
+  store %struct.group_ops__Element_bls12381__G1_ %retval, ptr %local_2, align 8
+  %load_store_tmp = load %struct.group_ops__Element_bls12381__G1_, ptr %local_2, align 8
+  store %struct.group_ops__Element_bls12381__G1_ %load_store_tmp, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load ptr, ptr %local_3, align 8
+  %call_arg_1 = load ptr, ptr %local_4, align 8
+  %retval2 = call %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_bls12381_g1_sub_3ry7MfF7roCAx2"(ptr %call_arg_0, ptr %call_arg_1)
+  store %struct.group_ops__Element_bls12381__G1_ %retval2, ptr %local_5, align 8
+  %retval3 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval3
+}
+
+define %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_bls12381_g1_sub_3ry7MfF7roCAx2"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 1, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_sub_6kADPapx16rjVE"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G1_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_sub_6kADPapx16rjVE"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__G1_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__G1_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_sub(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__G1_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__G1_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval7
+}
+
+declare { ptr, i64, i64 } @move_native_group_ops_internal_sub(i8, ptr, ptr)
+
+define %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_bls12381_g2_add_GpqT23gboaXZF7"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 2, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_add_9Uj64J4UymV5Lk"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G2_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_add_9Uj64J4UymV5Lk"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__G2_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__G2_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_add(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__G2_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__G2_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval7
+}
+
+define %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_bls12381_g2_div_B6no7gjLHngbNX"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 2, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_div_HV1VuvUJEpsJzJ"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G2_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_div_HV1VuvUJEpsJzJ"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__G2_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_div(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__G2_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__G2_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval7
+}
+
+define %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_bls12381_g2_from_bytes_31UyDF2TfxYWeM"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store i8 2, ptr %local_1, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_2, align 8
+  store i1 false, ptr %local_3, align 1
+  %call_arg_0 = load i8, ptr %local_1, align 1
+  %call_arg_1 = load ptr, ptr %local_2, align 8
+  %call_arg_2 = load i1, ptr %local_3, align 1
+  %retval = call %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_from_bytes_j6smeGkgCxdVLn"(i8 %call_arg_0, ptr %call_arg_1, i1 %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G2_ %retval, ptr %local_4, align 8
+  %retval1 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_4, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval1
+}
+
+define private %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_from_bytes_j6smeGkgCxdVLn"(i8 %0, ptr nonnull readonly %1, i1 %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i1, align 1
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca i1, align 1
+  %local_6 = alloca i8, align 1
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca i1, align 1
+  %local_10 = alloca ptr, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca ptr, align 8
+  %local_13__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_14 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store i1 %2, ptr %local_2, align 1
+  %load_store_tmp = load i1, ptr %local_2, align 1
+  store i1 %load_store_tmp, ptr %local_4, align 1
+  %cnd = load i1, ptr %local_4, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  store i1 true, ptr %local_5, align 1
+  %load_store_tmp1 = load i1, ptr %local_5, align 1
+  store i1 %load_store_tmp1, ptr %local_3, align 1
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp2 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp2, ptr %local_6, align 1
+  %load_store_tmp3 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp3, ptr %local_7, align 8
+  %loaded_alloca = load i8, ptr %local_6, align 1
+  %loaded_alloca4 = load ptr, ptr %local_7, align 8
+  %retval = call i1 @move_native_group_ops_internal_validate(i8 %loaded_alloca, ptr %loaded_alloca4)
+  store i1 %retval, ptr %local_8, align 1
+  %load_store_tmp5 = load i1, ptr %local_8, align 1
+  store i1 %load_store_tmp5, ptr %local_3, align 1
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_0, %bb_1
+  %load_store_tmp6 = load i1, ptr %local_3, align 1
+  store i1 %load_store_tmp6, ptr %local_9, align 1
+  %cnd7 = load i1, ptr %local_9, align 1
+  br i1 %cnd7, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  %load_store_tmp8 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp8, ptr %local_10, align 8
+  store i64 1, ptr %local_11, align 8
+  %call_arg_0 = load i64, ptr %local_11, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_5:                                             ; preds = %bb_4
+  %load_store_tmp9 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp9, ptr %local_12, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_12, align 8
+  %load_deref_store_tmp2 = load { ptr, i64, i64 }, ptr %load_deref_store_tmp1, align 8
+  store { ptr, i64, i64 } %load_deref_store_tmp2, ptr %local_13__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_13__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__G2_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__G2_ %insert_0, ptr %local_14, align 8
+  %retval10 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_14, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval10
+}
+
+define %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_bls12381_g2_generator_8ghjteC6GSs7vd"() {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.5)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_1, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_0, align 8
+  store i8 2, ptr %local_2, align 1
+  store ptr %local_0, ptr %local_3, align 8
+  store i1 true, ptr %local_4, align 1
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load i1, ptr %local_4, align 1
+  %retval = call %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_from_bytes_j6smeGkgCxdVLn"(i8 %call_arg_0, ptr %call_arg_1, i1 %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G2_ %retval, ptr %local_5, align 8
+  %retval1 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval1
+}
+
+define %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_bls12381_g2_identity_Cbvprps2eq1C5w"() {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.7)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_1, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_0, align 8
+  store i8 2, ptr %local_2, align 1
+  store ptr %local_0, ptr %local_3, align 8
+  store i1 true, ptr %local_4, align 1
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load i1, ptr %local_4, align 1
+  %retval = call %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_from_bytes_j6smeGkgCxdVLn"(i8 %call_arg_0, ptr %call_arg_1, i1 %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G2_ %retval, ptr %local_5, align 8
+  %retval1 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval1
+}
+
+define %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_bls12381_g2_mul_H9hm89jv8zuFjB"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 2, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_mul_FrpjDyKsfcXUL6"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G2_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_mul_FrpjDyKsfcXUL6"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__G2_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_mul(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__G2_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__G2_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval7
+}
+
+define %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_bls12381_g2_multi_scalar_FfCXhUKphu8UwK"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 2, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_multi_scalar_mu_DJW5AsZPxgPZ6x"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G2_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_multi_scalar_mu_DJW5AsZPxgPZ6x"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  %local_4 = alloca { ptr, i64, i64 }, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  %local_7 = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca ptr, align 8
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca i64, align 8
+  %local_11 = alloca i1, align 1
+  %local_12 = alloca ptr, align 8
+  %local_13 = alloca ptr, align 8
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca ptr, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca ptr, align 8
+  %local_18 = alloca i64, align 8
+  %local_19 = alloca i1, align 1
+  %local_20 = alloca ptr, align 8
+  %local_21 = alloca ptr, align 8
+  %local_22 = alloca i64, align 8
+  %local_23 = alloca { ptr, i64, i64 }, align 8
+  %local_24 = alloca { ptr, i64, i64 }, align 8
+  %local_25 = alloca i64, align 8
+  %local_26 = alloca i64, align 8
+  %local_27 = alloca ptr, align 8
+  %local_28 = alloca i64, align 8
+  %local_29 = alloca i1, align 1
+  %local_30 = alloca ptr, align 8
+  %local_31 = alloca i64, align 8
+  %local_32 = alloca ptr, align 8
+  %local_33 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  %local_34 = alloca ptr, align 8
+  %local_35 = alloca ptr, align 8
+  %local_36__bytes = alloca ptr, align 8
+  %local_37 = alloca { ptr, i64, i64 }, align 8
+  %local_38 = alloca ptr, align 8
+  %local_39 = alloca i64, align 8
+  %local_40 = alloca ptr, align 8
+  %local_41 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  %local_42 = alloca ptr, align 8
+  %local_43 = alloca ptr, align 8
+  %local_44__bytes = alloca ptr, align 8
+  %local_45 = alloca { ptr, i64, i64 }, align 8
+  %local_46 = alloca i64, align 8
+  %local_47 = alloca i64, align 8
+  %local_48 = alloca i64, align 8
+  %local_49 = alloca ptr, align 8
+  %local_50 = alloca ptr, align 8
+  %local_51 = alloca i8, align 1
+  %local_52 = alloca ptr, align 8
+  %local_53 = alloca ptr, align 8
+  %local_54__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_55 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp, ptr %local_8, align 8
+  %loaded_alloca = load ptr, ptr %local_8, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_group_ops__Element_bls12381__Scalar_, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_9, align 8
+  store i64 0, ptr %local_10, align 8
+  %gt_src_0 = load i64, ptr %local_9, align 8
+  %gt_src_1 = load i64, ptr %local_10, align 8
+  %gt_dst = icmp ugt i64 %gt_src_0, %gt_src_1
+  store i1 %gt_dst, ptr %local_11, align 1
+  %cnd = load i1, ptr %local_11, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_12, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_13, align 8
+  store i64 1, ptr %local_14, align 8
+  %call_arg_0 = load i64, ptr %local_14, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  %load_store_tmp3 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp3, ptr %local_15, align 8
+  %loaded_alloca4 = load ptr, ptr %local_15, align 8
+  %retval5 = call i64 @move_native_vector_length(ptr @__move_rttydesc_group_ops__Element_bls12381__Scalar_, ptr %loaded_alloca4)
+  store i64 %retval5, ptr %local_16, align 8
+  %load_store_tmp6 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp6, ptr %local_17, align 8
+  %loaded_alloca7 = load ptr, ptr %local_17, align 8
+  %retval8 = call i64 @move_native_vector_length(ptr @__move_rttydesc_group_ops__Element_bls12381__G2_, ptr %loaded_alloca7)
+  store i64 %retval8, ptr %local_18, align 8
+  %eq_src_0 = load i64, ptr %local_16, align 8
+  %eq_src_1 = load i64, ptr %local_18, align 8
+  %eq_dst = icmp eq i64 %eq_src_0, %eq_src_1
+  store i1 %eq_dst, ptr %local_19, align 1
+  %cnd9 = load i1, ptr %local_19, align 1
+  br i1 %cnd9, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  %load_store_tmp10 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp10, ptr %local_20, align 8
+  %load_store_tmp11 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp11, ptr %local_21, align 8
+  store i64 1, ptr %local_22, align 8
+  %call_arg_012 = load i64, ptr %local_22, align 8
+  call void @move_rt_abort(i64 %call_arg_012)
+  unreachable
+
+bb_5:                                             ; preds = %bb_4
+  %retval13 = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %retval13, ptr %local_23, align 8
+  %load_store_tmp14 = load { ptr, i64, i64 }, ptr %local_23, align 8
+  store { ptr, i64, i64 } %load_store_tmp14, ptr %local_7, align 8
+  %retval15 = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %retval15, ptr %local_24, align 8
+  %load_store_tmp16 = load { ptr, i64, i64 }, ptr %local_24, align 8
+  store { ptr, i64, i64 } %load_store_tmp16, ptr %local_4, align 8
+  store i64 0, ptr %local_25, align 8
+  %load_store_tmp17 = load i64, ptr %local_25, align 8
+  store i64 %load_store_tmp17, ptr %local_5, align 8
+  br label %bb_9
+
+bb_9:                                             ; preds = %join_bb, %bb_5
+  %load_store_tmp18 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp18, ptr %local_26, align 8
+  %load_store_tmp19 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp19, ptr %local_27, align 8
+  %loaded_alloca20 = load ptr, ptr %local_27, align 8
+  %retval21 = call i64 @move_native_vector_length(ptr @__move_rttydesc_group_ops__Element_bls12381__Scalar_, ptr %loaded_alloca20)
+  store i64 %retval21, ptr %local_28, align 8
+  %lt_src_0 = load i64, ptr %local_26, align 8
+  %lt_src_1 = load i64, ptr %local_28, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_29, align 1
+  %cnd22 = load i1, ptr %local_29, align 1
+  br i1 %cnd22, label %bb_7, label %bb_6
+
+bb_7:                                             ; preds = %bb_9
+  br label %bb_8
+
+bb_8:                                             ; preds = %bb_7
+  %load_store_tmp23 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp23, ptr %local_30, align 8
+  %load_store_tmp24 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp24, ptr %local_31, align 8
+  %loaded_alloca25 = load ptr, ptr %local_30, align 8
+  %loaded_alloca26 = load i64, ptr %local_31, align 8
+  %retval27 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_group_ops__Element_bls12381__Scalar_, ptr %loaded_alloca25, i64 %loaded_alloca26)
+  store ptr %retval27, ptr %local_32, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_32, align 8
+  %load_deref_store_tmp2 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %load_deref_store_tmp1, align 8
+  store %struct.group_ops__Element_bls12381__Scalar_ %load_deref_store_tmp2, ptr %local_33, align 8
+  %load_store_tmp28 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_33, align 8
+  store %struct.group_ops__Element_bls12381__Scalar_ %load_store_tmp28, ptr %local_6, align 8
+  store ptr %local_7, ptr %local_34, align 8
+  store ptr %local_6, ptr %local_35, align 8
+  %tmp = load ptr, ptr %local_35, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_36__bytes, align 8
+  %load_deref_store_tmp129 = load ptr, ptr %local_36__bytes, align 8
+  %load_deref_store_tmp230 = load { ptr, i64, i64 }, ptr %load_deref_store_tmp129, align 8
+  store { ptr, i64, i64 } %load_deref_store_tmp230, ptr %local_37, align 8
+  %call_arg_031 = load ptr, ptr %local_34, align 8
+  %call_arg_1 = load { ptr, i64, i64 }, ptr %local_37, align 8
+  call void @"0000000000000001_vector_append_9dqoPGavEhpvk5"(ptr %call_arg_031, { ptr, i64, i64 } %call_arg_1)
+  %load_store_tmp32 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp32, ptr %local_38, align 8
+  %load_store_tmp33 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp33, ptr %local_39, align 8
+  %loaded_alloca34 = load ptr, ptr %local_38, align 8
+  %loaded_alloca35 = load i64, ptr %local_39, align 8
+  %retval36 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_group_ops__Element_bls12381__G2_, ptr %loaded_alloca34, i64 %loaded_alloca35)
+  store ptr %retval36, ptr %local_40, align 8
+  %load_deref_store_tmp137 = load ptr, ptr %local_40, align 8
+  %load_deref_store_tmp238 = load %struct.group_ops__Element_bls12381__G2_, ptr %load_deref_store_tmp137, align 8
+  store %struct.group_ops__Element_bls12381__G2_ %load_deref_store_tmp238, ptr %local_41, align 8
+  %load_store_tmp39 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_41, align 8
+  store %struct.group_ops__Element_bls12381__G2_ %load_store_tmp39, ptr %local_3, align 8
+  store ptr %local_4, ptr %local_42, align 8
+  store ptr %local_3, ptr %local_43, align 8
+  %tmp40 = load ptr, ptr %local_43, align 8
+  %fld_ref41 = getelementptr inbounds %struct.group_ops__Element_bls12381__G2_, ptr %tmp40, i32 0, i32 0
+  store ptr %fld_ref41, ptr %local_44__bytes, align 8
+  %load_deref_store_tmp142 = load ptr, ptr %local_44__bytes, align 8
+  %load_deref_store_tmp243 = load { ptr, i64, i64 }, ptr %load_deref_store_tmp142, align 8
+  store { ptr, i64, i64 } %load_deref_store_tmp243, ptr %local_45, align 8
+  %call_arg_044 = load ptr, ptr %local_42, align 8
+  %call_arg_145 = load { ptr, i64, i64 }, ptr %local_45, align 8
+  call void @"0000000000000001_vector_append_9dqoPGavEhpvk5"(ptr %call_arg_044, { ptr, i64, i64 } %call_arg_145)
+  %load_store_tmp46 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp46, ptr %local_46, align 8
+  store i64 1, ptr %local_47, align 8
+  %add_src_0 = load i64, ptr %local_46, align 8
+  %add_src_1 = load i64, ptr %local_47, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_8
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_8
+  store i64 %add_dst, ptr %local_48, align 8
+  %load_store_tmp47 = load i64, ptr %local_48, align 8
+  store i64 %load_store_tmp47, ptr %local_5, align 8
+  br label %bb_9
+
+bb_6:                                             ; preds = %bb_9
+  %load_store_tmp48 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp48, ptr %local_49, align 8
+  %load_store_tmp49 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp49, ptr %local_50, align 8
+  %load_store_tmp50 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp50, ptr %local_51, align 1
+  store ptr %local_7, ptr %local_52, align 8
+  store ptr %local_4, ptr %local_53, align 8
+  %loaded_alloca51 = load i8, ptr %local_51, align 1
+  %loaded_alloca52 = load ptr, ptr %local_52, align 8
+  %loaded_alloca53 = load ptr, ptr %local_53, align 8
+  %retval54 = call { ptr, i64, i64 } @move_native_group_ops_internal_multi_scalar_mul(i8 %loaded_alloca51, ptr %loaded_alloca52, ptr %loaded_alloca53)
+  store { ptr, i64, i64 } %retval54, ptr %local_54__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_54__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__G2_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__G2_ %insert_0, ptr %local_55, align 8
+  %retval55 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_55, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval55
+}
+
+define %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_bls12381_g2_neg_H4ym6hz9xkNuuk"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  %local_2 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  store ptr %0, ptr %local_0, align 8
+  %retval = call %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_bls12381_g2_identity_Cbvprps2eq1C5w"()
+  store %struct.group_ops__Element_bls12381__G2_ %retval, ptr %local_2, align 8
+  %load_store_tmp = load %struct.group_ops__Element_bls12381__G2_, ptr %local_2, align 8
+  store %struct.group_ops__Element_bls12381__G2_ %load_store_tmp, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load ptr, ptr %local_3, align 8
+  %call_arg_1 = load ptr, ptr %local_4, align 8
+  %retval2 = call %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_bls12381_g2_sub_AQ5LyD8QWVfSHz"(ptr %call_arg_0, ptr %call_arg_1)
+  store %struct.group_ops__Element_bls12381__G2_ %retval2, ptr %local_5, align 8
+  %retval3 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval3
+}
+
+define %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_bls12381_g2_sub_AQ5LyD8QWVfSHz"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 2, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_sub_GsSFg4v9cRvfKX"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__G2_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_sub_GsSFg4v9cRvfKX"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__G2_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__G2_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_sub(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__G2_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__G2_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval7
+}
+
+define %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_bls12381_gt_add_2E8kwfE9TELhQe"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 3, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_group_ops_add_CwR1e8E5Fv2ezd"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__GT_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__GT_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__GT_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_group_ops_add_CwR1e8E5Fv2ezd"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__GT_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__GT_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_add(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__GT_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__GT_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__GT_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__GT_ %retval7
+}
+
+define %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_bls12381_gt_div_5nSAeJHJAZaNSA"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 3, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_group_ops_div_CzrnF6QRkgt6As"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__GT_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__GT_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__GT_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_group_ops_div_CzrnF6QRkgt6As"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__GT_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_div(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__GT_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__GT_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__GT_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__GT_ %retval7
+}
+
+define %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_bls12381_gt_generator_BGUH3fLGPq88sk"() {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.10)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_1, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_0, align 8
+  store i8 3, ptr %local_2, align 1
+  store ptr %local_0, ptr %local_3, align 8
+  store i1 true, ptr %local_4, align 1
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load i1, ptr %local_4, align 1
+  %retval = call %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_group_ops_from_bytes_FuMD6t5SASexMZ"(i8 %call_arg_0, ptr %call_arg_1, i1 %call_arg_2)
+  store %struct.group_ops__Element_bls12381__GT_ %retval, ptr %local_5, align 8
+  %retval1 = load %struct.group_ops__Element_bls12381__GT_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__GT_ %retval1
+}
+
+define private %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_group_ops_from_bytes_FuMD6t5SASexMZ"(i8 %0, ptr nonnull readonly %1, i1 %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i1, align 1
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca i1, align 1
+  %local_6 = alloca i8, align 1
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca i1, align 1
+  %local_10 = alloca ptr, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca ptr, align 8
+  %local_13__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_14 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store i1 %2, ptr %local_2, align 1
+  %load_store_tmp = load i1, ptr %local_2, align 1
+  store i1 %load_store_tmp, ptr %local_4, align 1
+  %cnd = load i1, ptr %local_4, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  store i1 true, ptr %local_5, align 1
+  %load_store_tmp1 = load i1, ptr %local_5, align 1
+  store i1 %load_store_tmp1, ptr %local_3, align 1
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp2 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp2, ptr %local_6, align 1
+  %load_store_tmp3 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp3, ptr %local_7, align 8
+  %loaded_alloca = load i8, ptr %local_6, align 1
+  %loaded_alloca4 = load ptr, ptr %local_7, align 8
+  %retval = call i1 @move_native_group_ops_internal_validate(i8 %loaded_alloca, ptr %loaded_alloca4)
+  store i1 %retval, ptr %local_8, align 1
+  %load_store_tmp5 = load i1, ptr %local_8, align 1
+  store i1 %load_store_tmp5, ptr %local_3, align 1
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_0, %bb_1
+  %load_store_tmp6 = load i1, ptr %local_3, align 1
+  store i1 %load_store_tmp6, ptr %local_9, align 1
+  %cnd7 = load i1, ptr %local_9, align 1
+  br i1 %cnd7, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  %load_store_tmp8 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp8, ptr %local_10, align 8
+  store i64 1, ptr %local_11, align 8
+  %call_arg_0 = load i64, ptr %local_11, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_5:                                             ; preds = %bb_4
+  %load_store_tmp9 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp9, ptr %local_12, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_12, align 8
+  %load_deref_store_tmp2 = load { ptr, i64, i64 }, ptr %load_deref_store_tmp1, align 8
+  store { ptr, i64, i64 } %load_deref_store_tmp2, ptr %local_13__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_13__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__GT_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__GT_ %insert_0, ptr %local_14, align 8
+  %retval10 = load %struct.group_ops__Element_bls12381__GT_, ptr %local_14, align 8
+  ret %struct.group_ops__Element_bls12381__GT_ %retval10
+}
+
+define %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_bls12381_gt_identity_EgfeSrVjdetfdh"() {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.12)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_1, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_0, align 8
+  store i8 3, ptr %local_2, align 1
+  store ptr %local_0, ptr %local_3, align 8
+  store i1 true, ptr %local_4, align 1
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load i1, ptr %local_4, align 1
+  %retval = call %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_group_ops_from_bytes_FuMD6t5SASexMZ"(i8 %call_arg_0, ptr %call_arg_1, i1 %call_arg_2)
+  store %struct.group_ops__Element_bls12381__GT_ %retval, ptr %local_5, align 8
+  %retval1 = load %struct.group_ops__Element_bls12381__GT_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__GT_ %retval1
+}
+
+define %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_bls12381_gt_mul_5MkCHJT7ShGFSj"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 3, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_group_ops_mul_GejSxRwG4vDm6D"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__GT_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__GT_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__GT_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_group_ops_mul_GejSxRwG4vDm6D"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__GT_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_mul(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__GT_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__GT_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__GT_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__GT_ %retval7
+}
+
+define %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_bls12381_gt_neg_A8rBbXAVLqf27R"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  %local_2 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  store ptr %0, ptr %local_0, align 8
+  %retval = call %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_bls12381_gt_identity_EgfeSrVjdetfdh"()
+  store %struct.group_ops__Element_bls12381__GT_ %retval, ptr %local_2, align 8
+  %load_store_tmp = load %struct.group_ops__Element_bls12381__GT_, ptr %local_2, align 8
+  store %struct.group_ops__Element_bls12381__GT_ %load_store_tmp, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load ptr, ptr %local_3, align 8
+  %call_arg_1 = load ptr, ptr %local_4, align 8
+  %retval2 = call %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_bls12381_gt_sub_DboGQWAGWkpW8U"(ptr %call_arg_0, ptr %call_arg_1)
+  store %struct.group_ops__Element_bls12381__GT_ %retval2, ptr %local_5, align 8
+  %retval3 = load %struct.group_ops__Element_bls12381__GT_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__GT_ %retval3
+}
+
+define %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_bls12381_gt_sub_DboGQWAGWkpW8U"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 3, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_group_ops_sub_8SPaEJkvZXAdtH"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__GT_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__GT_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__GT_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__GT_ @"0000000000000002_group_ops_sub_8SPaEJkvZXAdtH"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__GT_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__GT_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__GT_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_sub(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__GT_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__GT_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__GT_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__GT_ %retval7
+}
+
+define %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_bls12381_hash_to_g1_EUxhGYamoWxc2e"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store i8 1, ptr %local_1, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_2, align 8
+  %call_arg_0 = load i8, ptr %local_1, align 1
+  %call_arg_1 = load ptr, ptr %local_2, align 8
+  %retval = call %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_hash_to_4wg9DKUCJrWNNk"(i8 %call_arg_0, ptr %call_arg_1)
+  store %struct.group_ops__Element_bls12381__G1_ %retval, ptr %local_3, align 8
+  %retval1 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_3, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval1
+}
+
+define private %struct.group_ops__Element_bls12381__G1_ @"0000000000000002_group_ops_hash_to_4wg9DKUCJrWNNk"(i8 %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G1_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_2, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_3, align 8
+  %loaded_alloca = load i8, ptr %local_2, align 1
+  %loaded_alloca2 = load ptr, ptr %local_3, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_hash_to(i8 %loaded_alloca, ptr %loaded_alloca2)
+  store { ptr, i64, i64 } %retval, ptr %local_4__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_4__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__G1_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__G1_ %insert_0, ptr %local_5, align 8
+  %retval3 = load %struct.group_ops__Element_bls12381__G1_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G1_ %retval3
+}
+
+declare { ptr, i64, i64 } @move_native_group_ops_internal_hash_to(i8, ptr)
+
+define %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_bls12381_hash_to_g2_6WCAgW7nHpfMar"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store i8 2, ptr %local_1, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_2, align 8
+  %call_arg_0 = load i8, ptr %local_1, align 1
+  %call_arg_1 = load ptr, ptr %local_2, align 8
+  %retval = call %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_hash_to_GakJnfvg8pmn4j"(i8 %call_arg_0, ptr %call_arg_1)
+  store %struct.group_ops__Element_bls12381__G2_ %retval, ptr %local_3, align 8
+  %retval1 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_3, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval1
+}
+
+define private %struct.group_ops__Element_bls12381__G2_ @"0000000000000002_group_ops_hash_to_GakJnfvg8pmn4j"(i8 %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__G2_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_2, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_3, align 8
+  %loaded_alloca = load i8, ptr %local_2, align 1
+  %loaded_alloca2 = load ptr, ptr %local_3, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_hash_to(i8 %loaded_alloca, ptr %loaded_alloca2)
+  store { ptr, i64, i64 } %retval, ptr %local_4__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_4__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__G2_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__G2_ %insert_0, ptr %local_5, align 8
+  %retval3 = load %struct.group_ops__Element_bls12381__G2_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__G2_ %retval3
+}
+
+define %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_bls12381_scalar_add_BESryMqj22igY3"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 0, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_group_ops_add_GJSiPQ7w6ML4vC"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__Scalar_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__Scalar_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_group_ops_add_GJSiPQ7w6ML4vC"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_add(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__Scalar_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__Scalar_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__Scalar_ %retval7
+}
+
+define %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_bls12381_scalar_div_DtAMd7wbgP8xx8"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 0, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_group_ops_div_F6bX7bGTPt9VrL"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__Scalar_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__Scalar_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_group_ops_div_F6bX7bGTPt9VrL"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_div(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__Scalar_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__Scalar_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__Scalar_ %retval7
+}
+
+define %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_bls12381_scalar_from_byt_Gp7nPv942CNeM2"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store i8 0, ptr %local_1, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_2, align 8
+  store i1 false, ptr %local_3, align 1
+  %call_arg_0 = load i8, ptr %local_1, align 1
+  %call_arg_1 = load ptr, ptr %local_2, align 8
+  %call_arg_2 = load i1, ptr %local_3, align 1
+  %retval = call %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_group_ops_from_bytes_38Gnzow9pZZp2E"(i8 %call_arg_0, ptr %call_arg_1, i1 %call_arg_2)
+  store %struct.group_ops__Element_bls12381__Scalar_ %retval, ptr %local_4, align 8
+  %retval1 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_4, align 8
+  ret %struct.group_ops__Element_bls12381__Scalar_ %retval1
+}
+
+define private %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_group_ops_from_bytes_38Gnzow9pZZp2E"(i8 %0, ptr nonnull readonly %1, i1 %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i1, align 1
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca i1, align 1
+  %local_6 = alloca i8, align 1
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca i1, align 1
+  %local_10 = alloca ptr, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca ptr, align 8
+  %local_13__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_14 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store i1 %2, ptr %local_2, align 1
+  %load_store_tmp = load i1, ptr %local_2, align 1
+  store i1 %load_store_tmp, ptr %local_4, align 1
+  %cnd = load i1, ptr %local_4, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  store i1 true, ptr %local_5, align 1
+  %load_store_tmp1 = load i1, ptr %local_5, align 1
+  store i1 %load_store_tmp1, ptr %local_3, align 1
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp2 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp2, ptr %local_6, align 1
+  %load_store_tmp3 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp3, ptr %local_7, align 8
+  %loaded_alloca = load i8, ptr %local_6, align 1
+  %loaded_alloca4 = load ptr, ptr %local_7, align 8
+  %retval = call i1 @move_native_group_ops_internal_validate(i8 %loaded_alloca, ptr %loaded_alloca4)
+  store i1 %retval, ptr %local_8, align 1
+  %load_store_tmp5 = load i1, ptr %local_8, align 1
+  store i1 %load_store_tmp5, ptr %local_3, align 1
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_0, %bb_1
+  %load_store_tmp6 = load i1, ptr %local_3, align 1
+  store i1 %load_store_tmp6, ptr %local_9, align 1
+  %cnd7 = load i1, ptr %local_9, align 1
+  br i1 %cnd7, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  %load_store_tmp8 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp8, ptr %local_10, align 8
+  store i64 1, ptr %local_11, align 8
+  %call_arg_0 = load i64, ptr %local_11, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_5:                                             ; preds = %bb_4
+  %load_store_tmp9 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp9, ptr %local_12, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_12, align 8
+  %load_deref_store_tmp2 = load { ptr, i64, i64 }, ptr %load_deref_store_tmp1, align 8
+  store { ptr, i64, i64 } %load_deref_store_tmp2, ptr %local_13__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_13__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__Scalar_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__Scalar_ %insert_0, ptr %local_14, align 8
+  %retval10 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_14, align 8
+  ret %struct.group_ops__Element_bls12381__Scalar_ %retval10
+}
+
+define %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_bls12381_scalar_from_u64_8S2gzGe5uefDne"(i64 %0) {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca ptr, align 8
+  %local_6 = alloca i8, align 1
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  store i64 %0, ptr %local_0, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %1, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.14)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_2, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_2, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_1, align 8
+  %load_store_tmp1 = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp1, ptr %local_3, align 8
+  store i1 true, ptr %local_4, align 1
+  store ptr %local_1, ptr %local_5, align 8
+  %call_arg_0 = load i64, ptr %local_3, align 8
+  %call_arg_1 = load i1, ptr %local_4, align 1
+  %call_arg_2 = load ptr, ptr %local_5, align 8
+  call void @"0000000000000002_group_ops_set_as_prefix_6PXpVpsPpYLRpr"(i64 %call_arg_0, i1 %call_arg_1, ptr %call_arg_2)
+  store i8 0, ptr %local_6, align 1
+  store ptr %local_1, ptr %local_7, align 8
+  store i1 true, ptr %local_8, align 1
+  %call_arg_02 = load i8, ptr %local_6, align 1
+  %call_arg_13 = load ptr, ptr %local_7, align 8
+  %call_arg_24 = load i1, ptr %local_8, align 1
+  %retval = call %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_group_ops_from_bytes_38Gnzow9pZZp2E"(i8 %call_arg_02, ptr %call_arg_13, i1 %call_arg_24)
+  store %struct.group_ops__Element_bls12381__Scalar_ %retval, ptr %local_9, align 8
+  %retval5 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__Scalar_ %retval5
+}
+
+declare void @"0000000000000002_group_ops_set_as_prefix_6PXpVpsPpYLRpr"(i64, i1, ptr noalias nonnull)
+
+define %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_bls12381_scalar_inv_HoghGSgTkwTjna"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  %local_5 = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_3, align 8
+  store ptr %load_store_tmp1, ptr %local_2, align 8
+  %retval = call %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_bls12381_scalar_one_D5m3K5n6aApvSU"()
+  store %struct.group_ops__Element_bls12381__Scalar_ %retval, ptr %local_4, align 8
+  %load_store_tmp2 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_4, align 8
+  store %struct.group_ops__Element_bls12381__Scalar_ %load_store_tmp2, ptr %local_1, align 8
+  %load_store_tmp3 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp3, ptr %local_5, align 8
+  store ptr %local_1, ptr %local_6, align 8
+  %call_arg_0 = load ptr, ptr %local_5, align 8
+  %call_arg_1 = load ptr, ptr %local_6, align 8
+  %retval4 = call %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_bls12381_scalar_div_DtAMd7wbgP8xx8"(ptr %call_arg_0, ptr %call_arg_1)
+  store %struct.group_ops__Element_bls12381__Scalar_ %retval4, ptr %local_7, align 8
+  %retval5 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_7, align 8
+  ret %struct.group_ops__Element_bls12381__Scalar_ %retval5
+}
+
+define %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_bls12381_scalar_one_D5m3K5n6aApvSU"() {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.16)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_1, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_0, align 8
+  store i8 0, ptr %local_2, align 1
+  store ptr %local_0, ptr %local_3, align 8
+  store i1 true, ptr %local_4, align 1
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load i1, ptr %local_4, align 1
+  %retval = call %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_group_ops_from_bytes_38Gnzow9pZZp2E"(i8 %call_arg_0, ptr %call_arg_1, i1 %call_arg_2)
+  store %struct.group_ops__Element_bls12381__Scalar_ %retval, ptr %local_5, align 8
+  %retval1 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__Scalar_ %retval1
+}
+
+define %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_bls12381_scalar_mul_6CB6WiFiTkwW9a"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 0, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_group_ops_mul_Hsskt4LuSthNz4"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__Scalar_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__Scalar_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_group_ops_mul_Hsskt4LuSthNz4"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_mul(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__Scalar_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__Scalar_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__Scalar_ %retval7
+}
+
+define %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_bls12381_scalar_neg_99BiB1T9HDRHUN"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  %local_2 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  store ptr %0, ptr %local_0, align 8
+  %retval = call %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_bls12381_scalar_zero_3EtCCr6FofoZmW"()
+  store %struct.group_ops__Element_bls12381__Scalar_ %retval, ptr %local_2, align 8
+  %load_store_tmp = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_2, align 8
+  store %struct.group_ops__Element_bls12381__Scalar_ %load_store_tmp, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load ptr, ptr %local_3, align 8
+  %call_arg_1 = load ptr, ptr %local_4, align 8
+  %retval2 = call %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_bls12381_scalar_sub_J5q1BvQYs77kaD"(ptr %call_arg_0, ptr %call_arg_1)
+  store %struct.group_ops__Element_bls12381__Scalar_ %retval2, ptr %local_5, align 8
+  %retval3 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__Scalar_ %retval3
+}
+
+define %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_bls12381_scalar_zero_3EtCCr6FofoZmW"() {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.18)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_1, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_0, align 8
+  store i8 0, ptr %local_2, align 1
+  store ptr %local_0, ptr %local_3, align 8
+  store i1 true, ptr %local_4, align 1
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load i1, ptr %local_4, align 1
+  %retval = call %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_group_ops_from_bytes_38Gnzow9pZZp2E"(i8 %call_arg_0, ptr %call_arg_1, i1 %call_arg_2)
+  store %struct.group_ops__Element_bls12381__Scalar_ %retval, ptr %local_5, align 8
+  %retval1 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__Scalar_ %retval1
+}
+
+define %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_bls12381_scalar_sub_J5q1BvQYs77kaD"(ptr nonnull readonly %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  store ptr %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  store i8 0, ptr %local_2, align 1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %call_arg_0 = load i8, ptr %local_2, align 1
+  %call_arg_1 = load ptr, ptr %local_3, align 8
+  %call_arg_2 = load ptr, ptr %local_4, align 8
+  %retval = call %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_group_ops_sub_2GjcebmpuM3C2E"(i8 %call_arg_0, ptr %call_arg_1, ptr %call_arg_2)
+  store %struct.group_ops__Element_bls12381__Scalar_ %retval, ptr %local_5, align 8
+  %retval2 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_5, align 8
+  ret %struct.group_ops__Element_bls12381__Scalar_ %retval2
+}
+
+define private %struct.group_ops__Element_bls12381__Scalar_ @"0000000000000002_group_ops_sub_2GjcebmpuM3C2E"(i8 %0, ptr nonnull readonly %1, ptr nonnull readonly %2) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5__bytes = alloca ptr, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7__bytes = alloca ptr, align 8
+  %local_8__bytes = alloca { ptr, i64, i64 }, align 8
+  %local_9 = alloca %struct.group_ops__Element_bls12381__Scalar_, align 8
+  store i8 %0, ptr %local_0, align 1
+  store ptr %1, ptr %local_1, align 8
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_3, align 1
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_4, align 8
+  %tmp = load ptr, ptr %local_4, align 8
+  %fld_ref = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp, i32 0, i32 0
+  store ptr %fld_ref, ptr %local_5__bytes, align 8
+  %load_store_tmp2 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp2, ptr %local_6, align 8
+  %tmp3 = load ptr, ptr %local_6, align 8
+  %fld_ref4 = getelementptr inbounds %struct.group_ops__Element_bls12381__Scalar_, ptr %tmp3, i32 0, i32 0
+  store ptr %fld_ref4, ptr %local_7__bytes, align 8
+  %loaded_alloca = load i8, ptr %local_3, align 1
+  %loaded_alloca5 = load ptr, ptr %local_5__bytes, align 8
+  %loaded_alloca6 = load ptr, ptr %local_7__bytes, align 8
+  %retval = call { ptr, i64, i64 } @move_native_group_ops_internal_sub(i8 %loaded_alloca, ptr %loaded_alloca5, ptr %loaded_alloca6)
+  store { ptr, i64, i64 } %retval, ptr %local_8__bytes, align 8
+  %fv.0 = load { ptr, i64, i64 }, ptr %local_8__bytes, align 8
+  %insert_0 = insertvalue %struct.group_ops__Element_bls12381__Scalar_ undef, { ptr, i64, i64 } %fv.0, 0
+  store %struct.group_ops__Element_bls12381__Scalar_ %insert_0, ptr %local_9, align 8
+  %retval7 = load %struct.group_ops__Element_bls12381__Scalar_, ptr %local_9, align 8
+  ret %struct.group_ops__Element_bls12381__Scalar_ %retval7
+}
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)
+
+; Function Attrs: cold noreturn
+declare void @move_rt_abort(i64) #0
+
+declare { ptr, i64, i64 } @move_rt_vec_empty(ptr nonnull readonly dereferenceable(32))
+
+declare void @move_rt_vec_copy(ptr nonnull readonly dereferenceable(32), ptr nonnull dereferenceable(24), ptr nonnull readonly dereferenceable(24))
+
+attributes #0 = { cold noreturn }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__group_ops.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__group_ops.ll.expected
@@ -1,0 +1,276 @@
+; ModuleID = '0x2__group_ops'
+source_filename = "../../../../../../../crates/sui-framework/packages/sui-framework/sources/crypto/group_ops.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+@__move_rttydesc_u8 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u8_name, i64 2 }, i64 2, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u8_name = private unnamed_addr constant [2 x i8] c"u8"
+@__move_rttydesc_u64 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u64_name, i64 3 }, i64 5, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u64_name = private unnamed_addr constant [3 x i8] c"u64"
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define void @"0000000000000002_group_ops_unit_test_poiso_DAngiQst9P5bBT"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+declare { ptr, i64, i64 } @move_native_group_ops_internal_add(i8, ptr, ptr)
+
+declare { ptr, i64, i64 } @move_native_group_ops_internal_div(i8, ptr, ptr)
+
+declare { ptr, i64, i64 } @move_native_group_ops_internal_hash_to(i8, ptr)
+
+declare { ptr, i64, i64 } @move_native_group_ops_internal_mul(i8, ptr, ptr)
+
+declare { ptr, i64, i64 } @move_native_group_ops_internal_multi_scalar_mul(i8, ptr, ptr)
+
+declare { ptr, i64, i64 } @move_native_group_ops_internal_pairing(i8, ptr, ptr)
+
+declare { ptr, i64, i64 } @move_native_group_ops_internal_sub(i8, ptr, ptr)
+
+declare i1 @move_native_group_ops_internal_validate(i8, ptr)
+
+define void @"0000000000000002_group_ops_set_as_prefix_6PXpVpsPpYLRpr"(i64 %0, i1 %1, ptr noalias nonnull %2) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i1, align 1
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca i64, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca ptr, align 8
+  %local_9 = alloca ptr, align 8
+  %local_10 = alloca i64, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca i64, align 8
+  %local_13 = alloca i1, align 1
+  %local_14 = alloca ptr, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca ptr, align 8
+  %local_17 = alloca { ptr, i64, i64 }, align 8
+  %local_18 = alloca i64, align 8
+  %local_19 = alloca i64, align 8
+  %local_20 = alloca i64, align 8
+  %local_21 = alloca i1, align 1
+  %local_22 = alloca i1, align 1
+  %local_23 = alloca i64, align 8
+  %local_24 = alloca i64, align 8
+  %local_25 = alloca i64, align 8
+  %local_26 = alloca i64, align 8
+  %local_27 = alloca i64, align 8
+  %local_28 = alloca i64, align 8
+  %local_29 = alloca i64, align 8
+  %local_30 = alloca ptr, align 8
+  %local_31 = alloca i64, align 8
+  %local_32 = alloca ptr, align 8
+  %local_33 = alloca i8, align 1
+  %local_34 = alloca ptr, align 8
+  %local_35 = alloca i64, align 8
+  %local_36 = alloca ptr, align 8
+  %local_37 = alloca i64, align 8
+  %local_38 = alloca i64, align 8
+  %local_39 = alloca i64, align 8
+  %local_40 = alloca ptr, align 8
+  store i64 %0, ptr %local_0, align 8
+  store i1 %1, ptr %local_1, align 1
+  store ptr %2, ptr %local_2, align 8
+  %load_store_tmp = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp, ptr %local_8, align 8
+  %load_store_tmp1 = load ptr, ptr %local_8, align 8
+  store ptr %load_store_tmp1, ptr %local_9, align 8
+  %loaded_alloca = load ptr, ptr %local_9, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_10, align 8
+  %load_store_tmp2 = load i64, ptr %local_10, align 8
+  store i64 %load_store_tmp2, ptr %local_4, align 8
+  %load_store_tmp3 = load i64, ptr %local_4, align 8
+  store i64 %load_store_tmp3, ptr %local_11, align 8
+  store i64 7, ptr %local_12, align 8
+  %gt_src_0 = load i64, ptr %local_11, align 8
+  %gt_src_1 = load i64, ptr %local_12, align 8
+  %gt_dst = icmp ugt i64 %gt_src_0, %gt_src_1
+  store i1 %gt_dst, ptr %local_13, align 1
+  %cnd = load i1, ptr %local_13, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp4 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp4, ptr %local_14, align 8
+  store i64 3, ptr %local_15, align 8
+  %call_arg_0 = load i64, ptr %local_15, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  store ptr %local_0, ptr %local_16, align 8
+  %call_arg_05 = load ptr, ptr %local_16, align 8
+  %retval6 = call { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_6NhXVWFo2aWmc9"(ptr %call_arg_05)
+  store { ptr, i64, i64 } %retval6, ptr %local_17, align 8
+  %load_store_tmp7 = load { ptr, i64, i64 }, ptr %local_17, align 8
+  store { ptr, i64, i64 } %load_store_tmp7, ptr %local_7, align 8
+  store i64 0, ptr %local_18, align 8
+  %load_store_tmp8 = load i64, ptr %local_18, align 8
+  store i64 %load_store_tmp8, ptr %local_5, align 8
+  br label %bb_9
+
+bb_9:                                             ; preds = %join_bb38, %bb_2
+  %load_store_tmp9 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp9, ptr %local_19, align 8
+  store i64 8, ptr %local_20, align 8
+  %lt_src_0 = load i64, ptr %local_19, align 8
+  %lt_src_1 = load i64, ptr %local_20, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_21, align 1
+  %cnd10 = load i1, ptr %local_21, align 1
+  br i1 %cnd10, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_9
+  br label %bb_5
+
+bb_5:                                             ; preds = %bb_4
+  %load_store_tmp11 = load i1, ptr %local_1, align 1
+  store i1 %load_store_tmp11, ptr %local_22, align 1
+  %cnd12 = load i1, ptr %local_22, align 1
+  br i1 %cnd12, label %bb_7, label %bb_6
+
+bb_7:                                             ; preds = %bb_5
+  %load_store_tmp13 = load i64, ptr %local_4, align 8
+  store i64 %load_store_tmp13, ptr %local_23, align 8
+  %load_store_tmp14 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp14, ptr %local_24, align 8
+  %sub_src_0 = load i64, ptr %local_23, align 8
+  %sub_src_1 = load i64, ptr %local_24, align 8
+  %sub_dst = sub i64 %sub_src_0, %sub_src_1
+  %ovfcond = icmp ugt i64 %sub_dst, %sub_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_7
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_7
+  store i64 %sub_dst, ptr %local_25, align 8
+  store i64 1, ptr %local_26, align 8
+  %sub_src_015 = load i64, ptr %local_25, align 8
+  %sub_src_116 = load i64, ptr %local_26, align 8
+  %sub_dst17 = sub i64 %sub_src_015, %sub_src_116
+  %ovfcond18 = icmp ugt i64 %sub_dst17, %sub_src_015
+  br i1 %ovfcond18, label %then_bb19, label %join_bb20
+
+then_bb19:                                        ; preds = %join_bb
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb20:                                        ; preds = %join_bb
+  store i64 %sub_dst17, ptr %local_27, align 8
+  %load_store_tmp21 = load i64, ptr %local_27, align 8
+  store i64 %load_store_tmp21, ptr %local_3, align 8
+  br label %bb_8
+
+bb_6:                                             ; preds = %bb_5
+  %load_store_tmp22 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp22, ptr %local_28, align 8
+  %load_store_tmp23 = load i64, ptr %local_28, align 8
+  store i64 %load_store_tmp23, ptr %local_3, align 8
+  br label %bb_8
+
+bb_8:                                             ; preds = %bb_6, %join_bb20
+  %load_store_tmp24 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp24, ptr %local_29, align 8
+  %load_store_tmp25 = load i64, ptr %local_29, align 8
+  store i64 %load_store_tmp25, ptr %local_6, align 8
+  store ptr %local_7, ptr %local_30, align 8
+  %load_store_tmp26 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp26, ptr %local_31, align 8
+  %loaded_alloca27 = load ptr, ptr %local_30, align 8
+  %loaded_alloca28 = load i64, ptr %local_31, align 8
+  %retval29 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_u8, ptr %loaded_alloca27, i64 %loaded_alloca28)
+  store ptr %retval29, ptr %local_32, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_32, align 8
+  %load_deref_store_tmp2 = load i8, ptr %load_deref_store_tmp1, align 1
+  store i8 %load_deref_store_tmp2, ptr %local_33, align 1
+  %load_store_tmp30 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp30, ptr %local_34, align 8
+  %load_store_tmp31 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp31, ptr %local_35, align 8
+  %loaded_alloca32 = load ptr, ptr %local_34, align 8
+  %loaded_alloca33 = load i64, ptr %local_35, align 8
+  %retval34 = call ptr @move_native_vector_borrow_mut(ptr @__move_rttydesc_u8, ptr %loaded_alloca32, i64 %loaded_alloca33)
+  store ptr %retval34, ptr %local_36, align 8
+  %load_store_ref_src = load i8, ptr %local_33, align 1
+  %load_store_ref_dst_ptr = load ptr, ptr %local_36, align 8
+  store i8 %load_store_ref_src, ptr %load_store_ref_dst_ptr, align 1
+  %load_store_tmp35 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp35, ptr %local_37, align 8
+  store i64 1, ptr %local_38, align 8
+  %add_src_0 = load i64, ptr %local_37, align 8
+  %add_src_1 = load i64, ptr %local_38, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond36 = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond36, label %then_bb37, label %join_bb38
+
+then_bb37:                                        ; preds = %bb_8
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb38:                                        ; preds = %bb_8
+  store i64 %add_dst, ptr %local_39, align 8
+  %load_store_tmp39 = load i64, ptr %local_39, align 8
+  store i64 %load_store_tmp39, ptr %local_5, align 8
+  br label %bb_9
+
+bb_3:                                             ; preds = %bb_9
+  %load_store_tmp40 = load ptr, ptr %local_2, align 8
+  store ptr %load_store_tmp40, ptr %local_40, align 8
+  ret void
+}
+
+declare i64 @move_native_vector_length(ptr, ptr)
+
+define private { ptr, i64, i64 } @"0000000000000002_bcs_to_bytes_6NhXVWFo2aWmc9"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr @__move_rttydesc_u64, ptr %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %retval1 = load { ptr, i64, i64 }, ptr %local_2, align 8
+  ret { ptr, i64, i64 } %retval1
+}
+
+declare { ptr, i64, i64 } @move_native_bcs_to_bytes(ptr, ptr)
+
+declare ptr @move_native_vector_borrow(ptr, ptr, i64)
+
+declare ptr @move_native_vector_borrow_mut(ptr, ptr, i64)
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)
+
+; Function Attrs: cold noreturn
+declare void @move_rt_abort(i64) #0
+
+attributes #0 = { cold noreturn }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__hello.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__hello.ll.expected
@@ -1,0 +1,474 @@
+; ModuleID = '0x2__hello'
+source_filename = "drand-call.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+%struct.string__String = type { { ptr, i64, i64 } }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+@__move_rttydesc_u8 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u8_name, i64 2 }, i64 2, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u8_name = private unnamed_addr constant [2 x i8] c"u8"
+@vec_literal = internal constant [11 x i8] c"Hello drand"
+@vdesc = internal constant { ptr, i64, i64 } { ptr @vec_literal, i64 11, i64 11 }
+@__move_rttydesc_string__String = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_string__String_name, i64 80 }, i64 11, ptr @__move_rttydesc_string__String_info }
+@__move_rttydesc_string__String_name = private unnamed_addr constant [80 x i8] c"0000000000000000000000000000000000000000000000000000000000000001::string::String"
+@__move_rttydesc_vector_u8__name = private unnamed_addr constant [10 x i8] c"vector<u8>"
+@__move_rttydesc_vector_u8__info = private unnamed_addr constant { ptr } { ptr @__move_rttydesc_u8 }
+@0 = private unnamed_addr constant [5 x i8] c"bytes"
+@s_fld_array = private unnamed_addr constant [1 x { %__move_rt_type, i64, { ptr, i64 } }] [{ %__move_rt_type, i64, { ptr, i64 } } { %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_u8__name, i64 10 }, i64 10, ptr @__move_rttydesc_vector_u8__info }, i64 0, { ptr, i64 } { ptr @0, i64 5 } }]
+@__move_rttydesc_string__String_info = private unnamed_addr constant { ptr, i64, i64, i64 } { ptr @s_fld_array, i64 1, i64 24, i64 8 }
+@__move_rttydesc_u64 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u64_name, i64 3 }, i64 5, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u64_name = private unnamed_addr constant [3 x i8] c"u64"
+@__move_rttydesc_vector_u8_ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_u8__name, i64 10 }, i64 10, ptr @__move_rttydesc_vector_u8__info }
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define void @"0000000000000002_hello_unit_test_poiso_5Wk9dZ53vPWXRk"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+define i64 @"0000000000000002_hello_safe_selection_5mQFEnZcoqhs9c"(i64 %0, ptr nonnull readonly %1) {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i8, align 1
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca i64, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i1, align 1
+  %local_10 = alloca ptr, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca i64, align 8
+  %local_13 = alloca i64, align 8
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca i1, align 1
+  %local_17 = alloca i64, align 8
+  %local_18 = alloca i8, align 1
+  %local_19 = alloca i64, align 8
+  %local_20 = alloca ptr, align 8
+  %local_21 = alloca i64, align 8
+  %local_22 = alloca ptr, align 8
+  %local_23 = alloca i8, align 1
+  %local_24 = alloca i64, align 8
+  %local_25 = alloca i8, align 1
+  %local_26 = alloca i64, align 8
+  %local_27 = alloca i64, align 8
+  %local_28 = alloca i64, align 8
+  %local_29 = alloca i64, align 8
+  %local_30 = alloca i64, align 8
+  %local_31 = alloca ptr, align 8
+  %local_32 = alloca i64, align 8
+  %local_33 = alloca i64, align 8
+  %local_34 = alloca i64, align 8
+  %local_35 = alloca i64, align 8
+  %local_36 = alloca i64, align 8
+  %local_37 = alloca i64, align 8
+  store i64 %0, ptr %local_0, align 8
+  store ptr %1, ptr %local_1, align 8
+  %load_store_tmp = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp, ptr %local_6, align 8
+  %loaded_alloca = load ptr, ptr %local_6, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_7, align 8
+  store i64 8, ptr %local_8, align 8
+  %ge_src_0 = load i64, ptr %local_7, align 8
+  %ge_src_1 = load i64, ptr %local_8, align 8
+  %ge_dst = icmp uge i64 %ge_src_0, %ge_src_1
+  store i1 %ge_dst, ptr %local_9, align 1
+  %cnd = load i1, ptr %local_9, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  %load_store_tmp1 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp1, ptr %local_10, align 8
+  store i64 0, ptr %local_11, align 8
+  %call_arg_0 = load i64, ptr %local_11, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  store i64 0, ptr %local_12, align 8
+  %load_store_tmp2 = load i64, ptr %local_12, align 8
+  store i64 %load_store_tmp2, ptr %local_4, align 8
+  store i64 0, ptr %local_13, align 8
+  %load_store_tmp3 = load i64, ptr %local_13, align 8
+  store i64 %load_store_tmp3, ptr %local_3, align 8
+  br label %bb_6
+
+bb_6:                                             ; preds = %join_bb26, %bb_2
+  %load_store_tmp4 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp4, ptr %local_14, align 8
+  store i64 8, ptr %local_15, align 8
+  %lt_src_0 = load i64, ptr %local_14, align 8
+  %lt_src_1 = load i64, ptr %local_15, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_16, align 1
+  %cnd5 = load i1, ptr %local_16, align 1
+  br i1 %cnd5, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_6
+  br label %bb_5
+
+bb_5:                                             ; preds = %bb_4
+  %load_store_tmp6 = load i64, ptr %local_4, align 8
+  store i64 %load_store_tmp6, ptr %local_17, align 8
+  store i8 8, ptr %local_18, align 1
+  %shl_src_0 = load i64, ptr %local_17, align 8
+  %shl_src_1 = load i8, ptr %local_18, align 1
+  %rangecond = icmp uge i8 %shl_src_1, 64
+  br i1 %rangecond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_5
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_5
+  %zext_dst = zext i8 %shl_src_1 to i64
+  %shl_dst = shl i64 %shl_src_0, %zext_dst
+  store i64 %shl_dst, ptr %local_19, align 8
+  %load_store_tmp7 = load i64, ptr %local_19, align 8
+  store i64 %load_store_tmp7, ptr %local_4, align 8
+  %load_store_tmp8 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp8, ptr %local_20, align 8
+  %load_store_tmp9 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp9, ptr %local_21, align 8
+  %loaded_alloca10 = load ptr, ptr %local_20, align 8
+  %loaded_alloca11 = load i64, ptr %local_21, align 8
+  %retval12 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_u8, ptr %loaded_alloca10, i64 %loaded_alloca11)
+  store ptr %retval12, ptr %local_22, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_22, align 8
+  %load_deref_store_tmp2 = load i8, ptr %load_deref_store_tmp1, align 1
+  store i8 %load_deref_store_tmp2, ptr %local_23, align 1
+  %load_store_tmp13 = load i8, ptr %local_23, align 1
+  store i8 %load_store_tmp13, ptr %local_2, align 1
+  %load_store_tmp14 = load i64, ptr %local_4, align 8
+  store i64 %load_store_tmp14, ptr %local_24, align 8
+  %load_store_tmp15 = load i8, ptr %local_2, align 1
+  store i8 %load_store_tmp15, ptr %local_25, align 1
+  %cast_src = load i8, ptr %local_25, align 1
+  %zext_dst16 = zext i8 %cast_src to i64
+  store i64 %zext_dst16, ptr %local_26, align 8
+  %add_src_0 = load i64, ptr %local_24, align 8
+  %add_src_1 = load i64, ptr %local_26, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb17, label %join_bb18
+
+then_bb17:                                        ; preds = %join_bb
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb18:                                        ; preds = %join_bb
+  store i64 %add_dst, ptr %local_27, align 8
+  %load_store_tmp19 = load i64, ptr %local_27, align 8
+  store i64 %load_store_tmp19, ptr %local_4, align 8
+  %load_store_tmp20 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp20, ptr %local_28, align 8
+  store i64 1, ptr %local_29, align 8
+  %add_src_021 = load i64, ptr %local_28, align 8
+  %add_src_122 = load i64, ptr %local_29, align 8
+  %add_dst23 = add i64 %add_src_021, %add_src_122
+  %ovfcond24 = icmp ult i64 %add_dst23, %add_src_021
+  br i1 %ovfcond24, label %then_bb25, label %join_bb26
+
+then_bb25:                                        ; preds = %join_bb18
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb26:                                        ; preds = %join_bb18
+  store i64 %add_dst23, ptr %local_30, align 8
+  %load_store_tmp27 = load i64, ptr %local_30, align 8
+  store i64 %load_store_tmp27, ptr %local_3, align 8
+  br label %bb_6
+
+bb_3:                                             ; preds = %bb_6
+  %load_store_tmp28 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp28, ptr %local_31, align 8
+  %load_store_tmp29 = load i64, ptr %local_0, align 8
+  store i64 %load_store_tmp29, ptr %local_32, align 8
+  %cast_src30 = load i64, ptr %local_32, align 8
+  store i64 %cast_src30, ptr %local_33, align 8
+  %load_store_tmp31 = load i64, ptr %local_33, align 8
+  store i64 %load_store_tmp31, ptr %local_5, align 8
+  %load_store_tmp32 = load i64, ptr %local_4, align 8
+  store i64 %load_store_tmp32, ptr %local_34, align 8
+  %load_store_tmp33 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp33, ptr %local_35, align 8
+  %mod_src_0 = load i64, ptr %local_34, align 8
+  %mod_src_1 = load i64, ptr %local_35, align 8
+  %zerocond = icmp eq i64 %mod_src_1, 0
+  br i1 %zerocond, label %then_bb34, label %join_bb35
+
+then_bb34:                                        ; preds = %bb_3
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb35:                                        ; preds = %bb_3
+  %mod_dst = urem i64 %mod_src_0, %mod_src_1
+  store i64 %mod_dst, ptr %local_36, align 8
+  %cast_src36 = load i64, ptr %local_36, align 8
+  store i64 %cast_src36, ptr %local_37, align 8
+  %retval37 = load i64, ptr %local_37, align 8
+  ret i64 %retval37
+}
+
+declare i64 @move_native_vector_length(ptr, ptr)
+
+declare ptr @move_native_vector_borrow(ptr, ptr, i64)
+
+define { ptr, i64, i64 } @"0000000000000002_hello_create_u8_vecto_HP2kZVxAsexCP7"() {
+entry:
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca i8, align 1
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca i8, align 1
+  %local_6 = alloca ptr, align 8
+  %local_7 = alloca i8, align 1
+  %local_8 = alloca ptr, align 8
+  %local_9 = alloca i8, align 1
+  %local_10 = alloca ptr, align 8
+  %local_11 = alloca i8, align 1
+  %local_12 = alloca { ptr, i64, i64 }, align 8
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_0, align 8
+  store ptr %local_0, ptr %local_2, align 8
+  store i8 72, ptr %local_3, align 1
+  %loaded_alloca = load ptr, ptr %local_2, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca, ptr %local_3)
+  store ptr %local_0, ptr %local_4, align 8
+  store i8 101, ptr %local_5, align 1
+  %loaded_alloca1 = load ptr, ptr %local_4, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca1, ptr %local_5)
+  store ptr %local_0, ptr %local_6, align 8
+  store i8 108, ptr %local_7, align 1
+  %loaded_alloca2 = load ptr, ptr %local_6, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca2, ptr %local_7)
+  store ptr %local_0, ptr %local_8, align 8
+  store i8 108, ptr %local_9, align 1
+  %loaded_alloca3 = load ptr, ptr %local_8, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca3, ptr %local_9)
+  store ptr %local_0, ptr %local_10, align 8
+  store i8 111, ptr %local_11, align 1
+  %loaded_alloca4 = load ptr, ptr %local_10, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca4, ptr %local_11)
+  %load_store_tmp5 = load { ptr, i64, i64 }, ptr %local_0, align 8
+  store { ptr, i64, i64 } %load_store_tmp5, ptr %local_12, align 8
+  %retval6 = load { ptr, i64, i64 }, ptr %local_12, align 8
+  ret { ptr, i64, i64 } %retval6
+}
+
+declare { ptr, i64, i64 } @move_native_vector_empty(ptr)
+
+declare void @move_native_vector_push_back(ptr, ptr, ptr)
+
+define i64 @"0000000000000002_hello_main_CuppnyV29ZcpVB"() {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca %struct.string__String, align 8
+  %local_3 = alloca { ptr, i64, i64 }, align 8
+  %local_4 = alloca { ptr, i64, i64 }, align 8
+  %local_5 = alloca %struct.string__String, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7 = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca ptr, align 8
+  %local_9 = alloca { ptr, i64, i64 }, align 8
+  %local_10 = alloca { ptr, i64, i64 }, align 8
+  %local_11 = alloca ptr, align 8
+  %local_12 = alloca i64, align 8
+  %local_13 = alloca ptr, align 8
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca ptr, align 8
+  %local_16 = alloca i64, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_4, align 8
+  %call_arg_0 = load { ptr, i64, i64 }, ptr %local_4, align 8
+  %retval = call %struct.string__String @"0000000000000001_string_utf8_Fy6EqsEL4pdfgC"({ ptr, i64, i64 } %call_arg_0)
+  store %struct.string__String %retval, ptr %local_5, align 8
+  %load_store_tmp = load %struct.string__String, ptr %local_5, align 8
+  store %struct.string__String %load_store_tmp, ptr %local_2, align 8
+  store ptr %local_2, ptr %local_6, align 8
+  %loaded_alloca = load ptr, ptr %local_6, align 8
+  call void @move_native_debug_print(ptr @__move_rttydesc_string__String, ptr %loaded_alloca)
+  %retval1 = call { ptr, i64, i64 } @"0000000000000002_hello_create_u8_vecto_HP2kZVxAsexCP7"()
+  store { ptr, i64, i64 } %retval1, ptr %local_7, align 8
+  %load_store_tmp2 = load { ptr, i64, i64 }, ptr %local_7, align 8
+  store { ptr, i64, i64 } %load_store_tmp2, ptr %local_3, align 8
+  store ptr %local_3, ptr %local_8, align 8
+  %call_arg_03 = load ptr, ptr %local_8, align 8
+  call void @"0000000000000002_hello_print_vector_u8_EYYwwZrea9ZdcF"(ptr %call_arg_03)
+  %load_store_tmp4 = load { ptr, i64, i64 }, ptr %local_3, align 8
+  store { ptr, i64, i64 } %load_store_tmp4, ptr %local_9, align 8
+  %call_arg_05 = load { ptr, i64, i64 }, ptr %local_9, align 8
+  %retval6 = call { ptr, i64, i64 } @"0000000000000000_drand_lib_derive_randomne_6ohYzVYDX2EpLR"({ ptr, i64, i64 } %call_arg_05)
+  store { ptr, i64, i64 } %retval6, ptr %local_10, align 8
+  %load_store_tmp7 = load { ptr, i64, i64 }, ptr %local_10, align 8
+  store { ptr, i64, i64 } %load_store_tmp7, ptr %local_0, align 8
+  store ptr %local_0, ptr %local_11, align 8
+  %call_arg_08 = load ptr, ptr %local_11, align 8
+  call void @"0000000000000002_hello_print_vector_u8_EYYwwZrea9ZdcF"(ptr %call_arg_08)
+  store i64 64, ptr %local_12, align 8
+  store ptr %local_0, ptr %local_13, align 8
+  %call_arg_09 = load i64, ptr %local_12, align 8
+  %call_arg_1 = load ptr, ptr %local_13, align 8
+  %retval10 = call i64 @"0000000000000002_hello_safe_selection_5mQFEnZcoqhs9c"(i64 %call_arg_09, ptr %call_arg_1)
+  store i64 %retval10, ptr %local_14, align 8
+  %load_store_tmp11 = load i64, ptr %local_14, align 8
+  store i64 %load_store_tmp11, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_15, align 8
+  %loaded_alloca12 = load ptr, ptr %local_15, align 8
+  call void @move_native_debug_print(ptr @__move_rttydesc_u64, ptr %loaded_alloca12)
+  %load_store_tmp13 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp13, ptr %local_16, align 8
+  %retval14 = load i64, ptr %local_16, align 8
+  ret i64 %retval14
+}
+
+declare %struct.string__String @"0000000000000001_string_utf8_Fy6EqsEL4pdfgC"({ ptr, i64, i64 })
+
+declare void @move_native_debug_print(ptr, ptr)
+
+define void @"0000000000000002_hello_print_vector_u8_EYYwwZrea9ZdcF"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca { ptr, i64, i64 }, align 8
+  %local_5 = alloca { ptr, i64, i64 }, align 8
+  %local_6 = alloca ptr, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca i64, align 8
+  %local_11 = alloca i1, align 1
+  %local_12 = alloca ptr, align 8
+  %local_13 = alloca i64, align 8
+  %local_14 = alloca ptr, align 8
+  %local_15 = alloca ptr, align 8
+  %local_16 = alloca ptr, align 8
+  %local_17 = alloca i8, align 1
+  %local_18 = alloca i64, align 8
+  %local_19 = alloca i64, align 8
+  %local_20 = alloca i64, align 8
+  %local_21 = alloca ptr, align 8
+  %local_22 = alloca ptr, align 8
+  store ptr %0, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_vector_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %retval, ptr %local_5, align 8
+  %load_store_tmp = load { ptr, i64, i64 }, ptr %local_5, align 8
+  store { ptr, i64, i64 } %load_store_tmp, ptr %local_4, align 8
+  %load_store_tmp1 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp1, ptr %local_6, align 8
+  %loaded_alloca = load ptr, ptr %local_6, align 8
+  %retval2 = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval2, ptr %local_7, align 8
+  %load_store_tmp3 = load i64, ptr %local_7, align 8
+  store i64 %load_store_tmp3, ptr %local_3, align 8
+  store i64 0, ptr %local_8, align 8
+  %load_store_tmp4 = load i64, ptr %local_8, align 8
+  store i64 %load_store_tmp4, ptr %local_2, align 8
+  br label %bb_3
+
+bb_3:                                             ; preds = %join_bb, %entry
+  %load_store_tmp5 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp5, ptr %local_9, align 8
+  %load_store_tmp6 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp6, ptr %local_10, align 8
+  %lt_src_0 = load i64, ptr %local_9, align 8
+  %lt_src_1 = load i64, ptr %local_10, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_11, align 1
+  %cnd = load i1, ptr %local_11, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %bb_3
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_1
+  %load_store_tmp7 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp7, ptr %local_12, align 8
+  %load_store_tmp8 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp8, ptr %local_13, align 8
+  %loaded_alloca9 = load ptr, ptr %local_12, align 8
+  %loaded_alloca10 = load i64, ptr %local_13, align 8
+  %retval11 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_u8, ptr %loaded_alloca9, i64 %loaded_alloca10)
+  store ptr %retval11, ptr %local_14, align 8
+  %load_store_tmp12 = load ptr, ptr %local_14, align 8
+  store ptr %load_store_tmp12, ptr %local_1, align 8
+  store ptr %local_4, ptr %local_15, align 8
+  %load_store_tmp13 = load ptr, ptr %local_1, align 8
+  store ptr %load_store_tmp13, ptr %local_16, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_16, align 8
+  %load_deref_store_tmp2 = load i8, ptr %load_deref_store_tmp1, align 1
+  store i8 %load_deref_store_tmp2, ptr %local_17, align 1
+  %loaded_alloca14 = load ptr, ptr %local_15, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca14, ptr %local_17)
+  %load_store_tmp15 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp15, ptr %local_18, align 8
+  store i64 1, ptr %local_19, align 8
+  %add_src_0 = load i64, ptr %local_18, align 8
+  %add_src_1 = load i64, ptr %local_19, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_2
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_2
+  store i64 %add_dst, ptr %local_20, align 8
+  %load_store_tmp16 = load i64, ptr %local_20, align 8
+  store i64 %load_store_tmp16, ptr %local_2, align 8
+  br label %bb_3
+
+bb_0:                                             ; preds = %bb_3
+  %load_store_tmp17 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp17, ptr %local_21, align 8
+  store ptr %local_4, ptr %local_22, align 8
+  %loaded_alloca18 = load ptr, ptr %local_22, align 8
+  call void @move_native_debug_print(ptr @__move_rttydesc_vector_u8_, ptr %loaded_alloca18)
+  ret void
+}
+
+declare { ptr, i64, i64 } @"0000000000000000_drand_lib_derive_randomne_6ohYzVYDX2EpLR"({ ptr, i64, i64 })
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)
+
+; Function Attrs: cold noreturn
+declare void @move_rt_abort(i64) #0
+
+declare { ptr, i64, i64 } @move_rt_vec_empty(ptr nonnull readonly dereferenceable(32))
+
+declare void @move_rt_vec_copy(ptr nonnull readonly dereferenceable(32), ptr nonnull dereferenceable(24), ptr nonnull readonly dereferenceable(24))
+
+attributes #0 = { cold noreturn }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__hex.ll.expected
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__hex.ll.expected
@@ -1,0 +1,1466 @@
+; ModuleID = '0x2__hex'
+source_filename = "../../../../../../../crates/sui-framework/packages/sui-framework/sources/hex.move"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "sbf-solana-solana"
+
+%__move_rt_type = type { { ptr, i64 }, i64, ptr }
+
+@__move_rttydesc_signer = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_signer_name, i64 6 }, i64 9, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_signer_name = private unnamed_addr constant [6 x i8] c"signer"
+@__move_rttydesc_NOTHING_info = private unnamed_addr constant i8 -1
+@vec_literal = internal constant [0 x i8] zeroinitializer
+@vdesc = internal constant { ptr, i64, i64 } { ptr @vec_literal, i64 0, i64 0 }
+@__move_rttydesc_u8 = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_u8_name, i64 2 }, i64 2, ptr @__move_rttydesc_NOTHING_info }
+@__move_rttydesc_u8_name = private unnamed_addr constant [2 x i8] c"u8"
+@vec_literal.1 = internal constant [0 x i8] zeroinitializer
+@vdesc.2 = internal constant { ptr, i64, i64 } { ptr @vec_literal.1, i64 0, i64 0 }
+@vec_literal.3 = internal constant [2 x i8] c"00"
+@vdesc.4 = internal constant { ptr, i64, i64 } { ptr @vec_literal.3, i64 2, i64 2 }
+@__move_rttydesc_vector_u8_ = private unnamed_addr constant %__move_rt_type { { ptr, i64 } { ptr @__move_rttydesc_vector_u8__name, i64 10 }, i64 10, ptr @__move_rttydesc_vector_u8__info }
+@__move_rttydesc_vector_u8__name = private unnamed_addr constant [10 x i8] c"vector<u8>"
+@__move_rttydesc_vector_u8__info = private unnamed_addr constant { ptr } { ptr @__move_rttydesc_u8 }
+@vec_literal.5 = internal constant [2 x i8] c"\FF\FF"
+@vdesc.6 = internal constant { ptr, i64, i64 } { ptr @vec_literal.5, i64 2, i64 2 }
+@vec_literal.7 = internal constant [1 x i8] c"0"
+@vdesc.8 = internal constant { ptr, i64, i64 } { ptr @vec_literal.7, i64 1, i64 1 }
+@vec_literal.9 = internal constant [2 x i8] c"0g"
+@vdesc.10 = internal constant { ptr, i64, i64 } { ptr @vec_literal.9, i64 2, i64 2 }
+@vec_literal.11 = internal constant [1 x i8] c"\FF"
+@vdesc.12 = internal constant { ptr, i64, i64 } { ptr @vec_literal.11, i64 1, i64 1 }
+@vec_literal.13 = internal constant [2 x i8] c"ff"
+@vdesc.14 = internal constant { ptr, i64, i64 } { ptr @vec_literal.13, i64 2, i64 2 }
+@vec_literal.15 = internal constant [1 x i8] c"\FE"
+@vdesc.16 = internal constant { ptr, i64, i64 } { ptr @vec_literal.15, i64 1, i64 1 }
+@vec_literal.17 = internal constant [2 x i8] c"fe"
+@vdesc.18 = internal constant { ptr, i64, i64 } { ptr @vec_literal.17, i64 2, i64 2 }
+@vec_literal.19 = internal constant [1 x i8] zeroinitializer
+@vdesc.20 = internal constant { ptr, i64, i64 } { ptr @vec_literal.19, i64 1, i64 1 }
+@vec_literal.21 = internal constant [2 x i8] c"00"
+@vdesc.22 = internal constant { ptr, i64, i64 } { ptr @vec_literal.21, i64 2, i64 2 }
+@vec_literal.23 = internal constant [33 x i8] c"\03m$\16%*\E1\DB\8A\ED\ADY\E1K\00{\EEj\B9J>w\A3T\9A\81\13xq`DV\F3"
+@vdesc.24 = internal constant { ptr, i64, i64 } { ptr @vec_literal.23, i64 33, i64 33 }
+@vec_literal.25 = internal constant [66 x i8] c"036d2416252ae1Db8aedAd59e14b007bee6aB94a3e77a3549a81137871604456f3"
+@vdesc.26 = internal constant { ptr, i64, i64 } { ptr @vec_literal.25, i64 66, i64 66 }
+@vec_literal.27 = internal constant [1 x i8] c"\FF"
+@vdesc.28 = internal constant { ptr, i64, i64 } { ptr @vec_literal.27, i64 1, i64 1 }
+@vec_literal.29 = internal constant [2 x i8] c"Ff"
+@vdesc.30 = internal constant { ptr, i64, i64 } { ptr @vec_literal.29, i64 2, i64 2 }
+@vec_literal.31 = internal constant [1 x i8] c"\FF"
+@vdesc.32 = internal constant { ptr, i64, i64 } { ptr @vec_literal.31, i64 1, i64 1 }
+@vec_literal.33 = internal constant [2 x i8] c"fF"
+@vdesc.34 = internal constant { ptr, i64, i64 } { ptr @vec_literal.33, i64 2, i64 2 }
+@vec_literal.35 = internal constant [1 x i8] c"\FF"
+@vdesc.36 = internal constant { ptr, i64, i64 } { ptr @vec_literal.35, i64 1, i64 1 }
+@vec_literal.37 = internal constant [2 x i8] c"FF"
+@vdesc.38 = internal constant { ptr, i64, i64 } { ptr @vec_literal.37, i64 2, i64 2 }
+@vec_literal.39 = internal constant [2 x i8] c"ff"
+@vdesc.40 = internal constant { ptr, i64, i64 } { ptr @vec_literal.39, i64 2, i64 2 }
+@vec_literal.41 = internal constant [1 x i8] c"\FF"
+@vdesc.42 = internal constant { ptr, i64, i64 } { ptr @vec_literal.41, i64 1, i64 1 }
+@vec_literal.43 = internal constant [2 x i8] c"fe"
+@vdesc.44 = internal constant { ptr, i64, i64 } { ptr @vec_literal.43, i64 2, i64 2 }
+@vec_literal.45 = internal constant [1 x i8] c"\FE"
+@vdesc.46 = internal constant { ptr, i64, i64 } { ptr @vec_literal.45, i64 1, i64 1 }
+@vec_literal.47 = internal constant [2 x i8] c"00"
+@vdesc.48 = internal constant { ptr, i64, i64 } { ptr @vec_literal.47, i64 2, i64 2 }
+@vec_literal.49 = internal constant [1 x i8] zeroinitializer
+@vdesc.50 = internal constant { ptr, i64, i64 } { ptr @vec_literal.49, i64 1, i64 1 }
+@vec_literal.51 = internal constant [2 x i8] c"30"
+@vdesc.52 = internal constant { ptr, i64, i64 } { ptr @vec_literal.51, i64 2, i64 2 }
+@vec_literal.53 = internal constant [1 x i8] c"0"
+@vdesc.54 = internal constant { ptr, i64, i64 } { ptr @vec_literal.53, i64 1, i64 1 }
+@vec_literal.55 = internal constant [2 x i8] c"61"
+@vdesc.56 = internal constant { ptr, i64, i64 } { ptr @vec_literal.55, i64 2, i64 2 }
+@vec_literal.57 = internal constant [1 x i8] c"a"
+@vdesc.58 = internal constant { ptr, i64, i64 } { ptr @vec_literal.57, i64 1, i64 1 }
+@vec_literal.59 = internal constant [6 x i8] c"666666"
+@vdesc.60 = internal constant { ptr, i64, i64 } { ptr @vec_literal.59, i64 6, i64 6 }
+@vec_literal.61 = internal constant [3 x i8] c"fff"
+@vdesc.62 = internal constant { ptr, i64, i64 } { ptr @vec_literal.61, i64 3, i64 3 }
+
+declare i32 @memcmp(ptr, ptr, i64)
+
+define void @"0000000000000002_hex_unit_test_poiso_9SjmrJYNYb3xTr"() {
+entry:
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  store i64 0, ptr %local_0, align 8
+  %loaded_alloca = load i64, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64 %loaded_alloca)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_signer, ptr %local_1)
+  ret void
+}
+
+declare { ptr, i64, i64 } @move_native_unit_test_create_signers_for_testing(i64)
+
+define { ptr, i64, i64 } @"0000000000000002_hex_decode_6U7GZEKfu2EbsC"({ ptr, i64, i64 } %0) {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca i8, align 1
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca { ptr, i64, i64 }, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca { ptr, i64, i64 }, align 8
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca i64, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca i64, align 8
+  %local_13 = alloca i1, align 1
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca i1, align 1
+  %local_18 = alloca ptr, align 8
+  %local_19 = alloca i64, align 8
+  %local_20 = alloca ptr, align 8
+  %local_21 = alloca i8, align 1
+  %local_22 = alloca i8, align 1
+  %local_23 = alloca i8, align 1
+  %local_24 = alloca i8, align 1
+  %local_25 = alloca ptr, align 8
+  %local_26 = alloca i64, align 8
+  %local_27 = alloca i64, align 8
+  %local_28 = alloca i64, align 8
+  %local_29 = alloca ptr, align 8
+  %local_30 = alloca i8, align 1
+  %local_31 = alloca i8, align 1
+  %local_32 = alloca i8, align 1
+  %local_33 = alloca ptr, align 8
+  %local_34 = alloca i8, align 1
+  %local_35 = alloca i64, align 8
+  %local_36 = alloca i64, align 8
+  %local_37 = alloca i64, align 8
+  %local_38 = alloca { ptr, i64, i64 }, align 8
+  store { ptr, i64, i64 } %0, ptr %local_0, align 8
+  store i64 0, ptr %local_5, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %1, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_6, align 8
+  store ptr %local_0, ptr %local_7, align 8
+  %loaded_alloca = load ptr, ptr %local_7, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_8, align 8
+  %load_store_tmp = load i64, ptr %local_8, align 8
+  store i64 %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load { ptr, i64, i64 }, ptr %local_6, align 8
+  store { ptr, i64, i64 } %load_store_tmp1, ptr %local_4, align 8
+  %load_store_tmp2 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp2, ptr %local_2, align 8
+  %load_store_tmp3 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp3, ptr %local_9, align 8
+  store i64 2, ptr %local_10, align 8
+  %mod_src_0 = load i64, ptr %local_9, align 8
+  %mod_src_1 = load i64, ptr %local_10, align 8
+  %zerocond = icmp eq i64 %mod_src_1, 0
+  br i1 %zerocond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %entry
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %entry
+  %mod_dst = urem i64 %mod_src_0, %mod_src_1
+  store i64 %mod_dst, ptr %local_11, align 8
+  store i64 0, ptr %local_12, align 8
+  %eq_src_0 = load i64, ptr %local_11, align 8
+  %eq_src_1 = load i64, ptr %local_12, align 8
+  %eq_dst = icmp eq i64 %eq_src_0, %eq_src_1
+  store i1 %eq_dst, ptr %local_13, align 1
+  %cnd = load i1, ptr %local_13, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %join_bb
+  br label %bb_2
+
+bb_0:                                             ; preds = %join_bb
+  store i64 0, ptr %local_14, align 8
+  %call_arg_0 = load i64, ptr %local_14, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_2:                                             ; preds = %join_bb40, %bb_1
+  %load_store_tmp4 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp4, ptr %local_15, align 8
+  %load_store_tmp5 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp5, ptr %local_16, align 8
+  %lt_src_0 = load i64, ptr %local_15, align 8
+  %lt_src_1 = load i64, ptr %local_16, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_17, align 1
+  %cnd6 = load i1, ptr %local_17, align 1
+  br i1 %cnd6, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  br label %bb_5
+
+bb_5:                                             ; preds = %bb_4
+  store ptr %local_0, ptr %local_18, align 8
+  %load_store_tmp7 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp7, ptr %local_19, align 8
+  %loaded_alloca8 = load ptr, ptr %local_18, align 8
+  %loaded_alloca9 = load i64, ptr %local_19, align 8
+  %retval10 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_u8, ptr %loaded_alloca8, i64 %loaded_alloca9)
+  store ptr %retval10, ptr %local_20, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_20, align 8
+  %load_deref_store_tmp2 = load i8, ptr %load_deref_store_tmp1, align 1
+  store i8 %load_deref_store_tmp2, ptr %local_21, align 1
+  %call_arg_011 = load i8, ptr %local_21, align 1
+  %retval12 = call i8 @"0000000000000002_hex_decode_byte_GCZ6dKNoa2a5x5"(i8 %call_arg_011)
+  store i8 %retval12, ptr %local_22, align 1
+  store i8 16, ptr %local_23, align 1
+  %mul_src_0 = load i8, ptr %local_22, align 1
+  %mul_src_1 = load i8, ptr %local_23, align 1
+  %mul_val = call { i8, i1 } @llvm.umul.with.overflow.i8(i8 %mul_src_0, i8 %mul_src_1)
+  %mul_dst = extractvalue { i8, i1 } %mul_val, 0
+  %mul_ovf = extractvalue { i8, i1 } %mul_val, 1
+  br i1 %mul_ovf, label %then_bb13, label %join_bb14
+
+then_bb13:                                        ; preds = %bb_5
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb14:                                        ; preds = %bb_5
+  store i8 %mul_dst, ptr %local_24, align 1
+  store ptr %local_0, ptr %local_25, align 8
+  %load_store_tmp15 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp15, ptr %local_26, align 8
+  store i64 1, ptr %local_27, align 8
+  %add_src_0 = load i64, ptr %local_26, align 8
+  %add_src_1 = load i64, ptr %local_27, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb16, label %join_bb17
+
+then_bb16:                                        ; preds = %join_bb14
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb17:                                        ; preds = %join_bb14
+  store i64 %add_dst, ptr %local_28, align 8
+  %loaded_alloca18 = load ptr, ptr %local_25, align 8
+  %loaded_alloca19 = load i64, ptr %local_28, align 8
+  %retval20 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_u8, ptr %loaded_alloca18, i64 %loaded_alloca19)
+  store ptr %retval20, ptr %local_29, align 8
+  %load_deref_store_tmp121 = load ptr, ptr %local_29, align 8
+  %load_deref_store_tmp222 = load i8, ptr %load_deref_store_tmp121, align 1
+  store i8 %load_deref_store_tmp222, ptr %local_30, align 1
+  %call_arg_023 = load i8, ptr %local_30, align 1
+  %retval24 = call i8 @"0000000000000002_hex_decode_byte_GCZ6dKNoa2a5x5"(i8 %call_arg_023)
+  store i8 %retval24, ptr %local_31, align 1
+  %add_src_025 = load i8, ptr %local_24, align 1
+  %add_src_126 = load i8, ptr %local_31, align 1
+  %add_dst27 = add i8 %add_src_025, %add_src_126
+  %ovfcond28 = icmp ult i8 %add_dst27, %add_src_025
+  br i1 %ovfcond28, label %then_bb29, label %join_bb30
+
+then_bb29:                                        ; preds = %join_bb17
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb30:                                        ; preds = %join_bb17
+  store i8 %add_dst27, ptr %local_32, align 1
+  %load_store_tmp31 = load i8, ptr %local_32, align 1
+  store i8 %load_store_tmp31, ptr %local_1, align 1
+  store ptr %local_4, ptr %local_33, align 8
+  %load_store_tmp32 = load i8, ptr %local_1, align 1
+  store i8 %load_store_tmp32, ptr %local_34, align 1
+  %loaded_alloca33 = load ptr, ptr %local_33, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca33, ptr %local_34)
+  %load_store_tmp34 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp34, ptr %local_35, align 8
+  store i64 2, ptr %local_36, align 8
+  %add_src_035 = load i64, ptr %local_35, align 8
+  %add_src_136 = load i64, ptr %local_36, align 8
+  %add_dst37 = add i64 %add_src_035, %add_src_136
+  %ovfcond38 = icmp ult i64 %add_dst37, %add_src_035
+  br i1 %ovfcond38, label %then_bb39, label %join_bb40
+
+then_bb39:                                        ; preds = %join_bb30
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb40:                                        ; preds = %join_bb30
+  store i64 %add_dst37, ptr %local_37, align 8
+  %load_store_tmp41 = load i64, ptr %local_37, align 8
+  store i64 %load_store_tmp41, ptr %local_2, align 8
+  br label %bb_2
+
+bb_3:                                             ; preds = %bb_2
+  %load_store_tmp42 = load { ptr, i64, i64 }, ptr %local_4, align 8
+  store { ptr, i64, i64 } %load_store_tmp42, ptr %local_38, align 8
+  %retval43 = load { ptr, i64, i64 }, ptr %local_38, align 8
+  ret { ptr, i64, i64 } %retval43
+}
+
+declare i64 @move_native_vector_length(ptr, ptr)
+
+declare ptr @move_native_vector_borrow(ptr, ptr, i64)
+
+define private i8 @"0000000000000002_hex_decode_byte_GCZ6dKNoa2a5x5"(i8 %0) {
+entry:
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i1, align 1
+  %local_2 = alloca i1, align 1
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i8, align 1
+  %local_5 = alloca i8, align 1
+  %local_6 = alloca i8, align 1
+  %local_7 = alloca i8, align 1
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca i8, align 1
+  %local_10 = alloca i8, align 1
+  %local_11 = alloca i1, align 1
+  %local_12 = alloca i1, align 1
+  %local_13 = alloca i1, align 1
+  %local_14 = alloca i8, align 1
+  %local_15 = alloca i8, align 1
+  %local_16 = alloca i8, align 1
+  %local_17 = alloca i8, align 1
+  %local_18 = alloca i8, align 1
+  %local_19 = alloca i1, align 1
+  %local_20 = alloca i8, align 1
+  %local_21 = alloca i8, align 1
+  %local_22 = alloca i1, align 1
+  %local_23 = alloca i1, align 1
+  %local_24 = alloca i1, align 1
+  %local_25 = alloca i8, align 1
+  %local_26 = alloca i8, align 1
+  %local_27 = alloca i8, align 1
+  %local_28 = alloca i8, align 1
+  %local_29 = alloca i8, align 1
+  %local_30 = alloca i8, align 1
+  %local_31 = alloca i8, align 1
+  %local_32 = alloca i1, align 1
+  %local_33 = alloca i8, align 1
+  %local_34 = alloca i8, align 1
+  %local_35 = alloca i1, align 1
+  %local_36 = alloca i1, align 1
+  %local_37 = alloca i1, align 1
+  %local_38 = alloca i64, align 8
+  %local_39 = alloca i8, align 1
+  %local_40 = alloca i8, align 1
+  %local_41 = alloca i8, align 1
+  %local_42 = alloca i8, align 1
+  %local_43 = alloca i8, align 1
+  %local_44 = alloca i8, align 1
+  %local_45 = alloca i8, align 1
+  store i8 %0, ptr %local_0, align 1
+  store i8 48, ptr %local_6, align 1
+  %load_store_tmp = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp, ptr %local_7, align 1
+  %le_src_0 = load i8, ptr %local_6, align 1
+  %le_src_1 = load i8, ptr %local_7, align 1
+  %le_dst = icmp ule i8 %le_src_0, %le_src_1
+  store i1 %le_dst, ptr %local_8, align 1
+  %cnd = load i1, ptr %local_8, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  %load_store_tmp1 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp1, ptr %local_9, align 1
+  store i8 58, ptr %local_10, align 1
+  %lt_src_0 = load i8, ptr %local_9, align 1
+  %lt_src_1 = load i8, ptr %local_10, align 1
+  %lt_dst = icmp ult i8 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_11, align 1
+  %load_store_tmp2 = load i1, ptr %local_11, align 1
+  store i1 %load_store_tmp2, ptr %local_1, align 1
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i1 false, ptr %local_12, align 1
+  %load_store_tmp3 = load i1, ptr %local_12, align 1
+  store i1 %load_store_tmp3, ptr %local_1, align 1
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_0, %bb_1
+  %load_store_tmp4 = load i1, ptr %local_1, align 1
+  store i1 %load_store_tmp4, ptr %local_13, align 1
+  %cnd5 = load i1, ptr %local_13, align 1
+  br i1 %cnd5, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  %load_store_tmp6 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp6, ptr %local_14, align 1
+  store i8 48, ptr %local_15, align 1
+  %sub_src_0 = load i8, ptr %local_14, align 1
+  %sub_src_1 = load i8, ptr %local_15, align 1
+  %sub_dst = sub i8 %sub_src_0, %sub_src_1
+  %ovfcond = icmp ugt i8 %sub_dst, %sub_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_4
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_4
+  store i8 %sub_dst, ptr %local_16, align 1
+  %load_store_tmp7 = load i8, ptr %local_16, align 1
+  store i8 %load_store_tmp7, ptr %local_5, align 1
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  store i8 65, ptr %local_17, align 1
+  %load_store_tmp8 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp8, ptr %local_18, align 1
+  %le_src_09 = load i8, ptr %local_17, align 1
+  %le_src_110 = load i8, ptr %local_18, align 1
+  %le_dst11 = icmp ule i8 %le_src_09, %le_src_110
+  store i1 %le_dst11, ptr %local_19, align 1
+  %cnd12 = load i1, ptr %local_19, align 1
+  br i1 %cnd12, label %bb_7, label %bb_6
+
+bb_7:                                             ; preds = %bb_3
+  %load_store_tmp13 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp13, ptr %local_20, align 1
+  store i8 71, ptr %local_21, align 1
+  %lt_src_014 = load i8, ptr %local_20, align 1
+  %lt_src_115 = load i8, ptr %local_21, align 1
+  %lt_dst16 = icmp ult i8 %lt_src_014, %lt_src_115
+  store i1 %lt_dst16, ptr %local_22, align 1
+  %load_store_tmp17 = load i1, ptr %local_22, align 1
+  store i1 %load_store_tmp17, ptr %local_2, align 1
+  br label %bb_8
+
+bb_6:                                             ; preds = %bb_3
+  store i1 false, ptr %local_23, align 1
+  %load_store_tmp18 = load i1, ptr %local_23, align 1
+  store i1 %load_store_tmp18, ptr %local_2, align 1
+  br label %bb_8
+
+bb_8:                                             ; preds = %bb_6, %bb_7
+  %load_store_tmp19 = load i1, ptr %local_2, align 1
+  store i1 %load_store_tmp19, ptr %local_24, align 1
+  %cnd20 = load i1, ptr %local_24, align 1
+  br i1 %cnd20, label %bb_10, label %bb_9
+
+bb_10:                                            ; preds = %bb_8
+  store i8 10, ptr %local_25, align 1
+  %load_store_tmp21 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp21, ptr %local_26, align 1
+  %add_src_0 = load i8, ptr %local_25, align 1
+  %add_src_1 = load i8, ptr %local_26, align 1
+  %add_dst = add i8 %add_src_0, %add_src_1
+  %ovfcond22 = icmp ult i8 %add_dst, %add_src_0
+  br i1 %ovfcond22, label %then_bb23, label %join_bb24
+
+then_bb23:                                        ; preds = %bb_10
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb24:                                        ; preds = %bb_10
+  store i8 %add_dst, ptr %local_27, align 1
+  store i8 65, ptr %local_28, align 1
+  %sub_src_025 = load i8, ptr %local_27, align 1
+  %sub_src_126 = load i8, ptr %local_28, align 1
+  %sub_dst27 = sub i8 %sub_src_025, %sub_src_126
+  %ovfcond28 = icmp ugt i8 %sub_dst27, %sub_src_025
+  br i1 %ovfcond28, label %then_bb29, label %join_bb30
+
+then_bb29:                                        ; preds = %join_bb24
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb30:                                        ; preds = %join_bb24
+  store i8 %sub_dst27, ptr %local_29, align 1
+  %load_store_tmp31 = load i8, ptr %local_29, align 1
+  store i8 %load_store_tmp31, ptr %local_4, align 1
+  br label %bb_11
+
+bb_9:                                             ; preds = %bb_8
+  store i8 97, ptr %local_30, align 1
+  %load_store_tmp32 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp32, ptr %local_31, align 1
+  %le_src_033 = load i8, ptr %local_30, align 1
+  %le_src_134 = load i8, ptr %local_31, align 1
+  %le_dst35 = icmp ule i8 %le_src_033, %le_src_134
+  store i1 %le_dst35, ptr %local_32, align 1
+  %cnd36 = load i1, ptr %local_32, align 1
+  br i1 %cnd36, label %bb_13, label %bb_12
+
+bb_13:                                            ; preds = %bb_9
+  %load_store_tmp37 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp37, ptr %local_33, align 1
+  store i8 103, ptr %local_34, align 1
+  %lt_src_038 = load i8, ptr %local_33, align 1
+  %lt_src_139 = load i8, ptr %local_34, align 1
+  %lt_dst40 = icmp ult i8 %lt_src_038, %lt_src_139
+  store i1 %lt_dst40, ptr %local_35, align 1
+  %load_store_tmp41 = load i1, ptr %local_35, align 1
+  store i1 %load_store_tmp41, ptr %local_3, align 1
+  br label %bb_14
+
+bb_12:                                            ; preds = %bb_9
+  store i1 false, ptr %local_36, align 1
+  %load_store_tmp42 = load i1, ptr %local_36, align 1
+  store i1 %load_store_tmp42, ptr %local_3, align 1
+  br label %bb_14
+
+bb_14:                                            ; preds = %bb_12, %bb_13
+  %load_store_tmp43 = load i1, ptr %local_3, align 1
+  store i1 %load_store_tmp43, ptr %local_37, align 1
+  %cnd44 = load i1, ptr %local_37, align 1
+  br i1 %cnd44, label %bb_16, label %bb_15
+
+bb_16:                                            ; preds = %bb_14
+  br label %bb_17
+
+bb_15:                                            ; preds = %bb_14
+  store i64 1, ptr %local_38, align 8
+  %call_arg_0 = load i64, ptr %local_38, align 8
+  call void @move_rt_abort(i64 %call_arg_0)
+  unreachable
+
+bb_17:                                            ; preds = %bb_16
+  store i8 10, ptr %local_39, align 1
+  %load_store_tmp45 = load i8, ptr %local_0, align 1
+  store i8 %load_store_tmp45, ptr %local_40, align 1
+  %add_src_046 = load i8, ptr %local_39, align 1
+  %add_src_147 = load i8, ptr %local_40, align 1
+  %add_dst48 = add i8 %add_src_046, %add_src_147
+  %ovfcond49 = icmp ult i8 %add_dst48, %add_src_046
+  br i1 %ovfcond49, label %then_bb50, label %join_bb51
+
+then_bb50:                                        ; preds = %bb_17
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb51:                                        ; preds = %bb_17
+  store i8 %add_dst48, ptr %local_41, align 1
+  store i8 97, ptr %local_42, align 1
+  %sub_src_052 = load i8, ptr %local_41, align 1
+  %sub_src_153 = load i8, ptr %local_42, align 1
+  %sub_dst54 = sub i8 %sub_src_052, %sub_src_153
+  %ovfcond55 = icmp ugt i8 %sub_dst54, %sub_src_052
+  br i1 %ovfcond55, label %then_bb56, label %join_bb57
+
+then_bb56:                                        ; preds = %join_bb51
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb57:                                        ; preds = %join_bb51
+  store i8 %sub_dst54, ptr %local_43, align 1
+  %load_store_tmp58 = load i8, ptr %local_43, align 1
+  store i8 %load_store_tmp58, ptr %local_4, align 1
+  br label %bb_11
+
+bb_11:                                            ; preds = %join_bb57, %join_bb30
+  %load_store_tmp59 = load i8, ptr %local_4, align 1
+  store i8 %load_store_tmp59, ptr %local_44, align 1
+  %load_store_tmp60 = load i8, ptr %local_44, align 1
+  store i8 %load_store_tmp60, ptr %local_5, align 1
+  br label %bb_5
+
+bb_5:                                             ; preds = %bb_11, %join_bb
+  %load_store_tmp61 = load i8, ptr %local_5, align 1
+  store i8 %load_store_tmp61, ptr %local_45, align 1
+  %retval = load i8, ptr %local_45, align 1
+  ret i8 %retval
+}
+
+declare void @move_native_vector_push_back(ptr, ptr, ptr)
+
+define { ptr, i64, i64 } @"0000000000000002_hex_encode_2jkRtUUZsDAoo8"({ ptr, i64, i64 } %0) {
+entry:
+  %newv3 = alloca { ptr, i64, i64 }, align 8
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca { ptr, i64, i64 }, align 8
+  %local_5 = alloca i64, align 8
+  %local_6 = alloca { ptr, i64, i64 }, align 8
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca { ptr, i64, i64 }, align 8
+  %local_10 = alloca i64, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca i1, align 1
+  %local_13 = alloca ptr, align 8
+  %local_14 = alloca ptr, align 8
+  %local_15 = alloca ptr, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca ptr, align 8
+  %local_18 = alloca i8, align 1
+  %local_19 = alloca i64, align 8
+  %local_20 = alloca ptr, align 8
+  %local_21 = alloca { ptr, i64, i64 }, align 8
+  %local_22 = alloca i64, align 8
+  %local_23 = alloca i64, align 8
+  %local_24 = alloca i64, align 8
+  %local_25 = alloca { ptr, i64, i64 }, align 8
+  store { ptr, i64, i64 } %0, ptr %local_0, align 8
+  store i64 0, ptr %local_5, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %1, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.2)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_6, align 8
+  store ptr %local_0, ptr %local_7, align 8
+  %loaded_alloca = load ptr, ptr %local_7, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_8, align 8
+  %load_store_tmp = load i64, ptr %local_8, align 8
+  store i64 %load_store_tmp, ptr %local_3, align 8
+  %load_store_tmp1 = load { ptr, i64, i64 }, ptr %local_6, align 8
+  store { ptr, i64, i64 } %load_store_tmp1, ptr %local_4, align 8
+  %load_store_tmp2 = load i64, ptr %local_5, align 8
+  store i64 %load_store_tmp2, ptr %local_2, align 8
+  %2 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %2, ptr %newv3, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv3, ptr @vdesc.4)
+  %reload4 = load { ptr, i64, i64 }, ptr %newv3, align 8
+  store { ptr, i64, i64 } %reload4, ptr %local_9, align 8
+  %load_store_tmp5 = load { ptr, i64, i64 }, ptr %local_9, align 8
+  store { ptr, i64, i64 } %load_store_tmp5, ptr %local_1, align 8
+  br label %bb_3
+
+bb_3:                                             ; preds = %join_bb, %entry
+  %load_store_tmp6 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp6, ptr %local_10, align 8
+  %load_store_tmp7 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp7, ptr %local_11, align 8
+  %lt_src_0 = load i64, ptr %local_10, align 8
+  %lt_src_1 = load i64, ptr %local_11, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_12, align 1
+  %cnd = load i1, ptr %local_12, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %bb_3
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_1
+  store ptr %local_4, ptr %local_13, align 8
+  store ptr %local_1, ptr %local_14, align 8
+  store ptr %local_0, ptr %local_15, align 8
+  %load_store_tmp8 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp8, ptr %local_16, align 8
+  %loaded_alloca9 = load ptr, ptr %local_15, align 8
+  %loaded_alloca10 = load i64, ptr %local_16, align 8
+  %retval11 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_u8, ptr %loaded_alloca9, i64 %loaded_alloca10)
+  store ptr %retval11, ptr %local_17, align 8
+  %load_deref_store_tmp1 = load ptr, ptr %local_17, align 8
+  %load_deref_store_tmp2 = load i8, ptr %load_deref_store_tmp1, align 1
+  store i8 %load_deref_store_tmp2, ptr %local_18, align 1
+  %cast_src = load i8, ptr %local_18, align 1
+  %zext_dst = zext i8 %cast_src to i64
+  store i64 %zext_dst, ptr %local_19, align 8
+  %loaded_alloca12 = load ptr, ptr %local_14, align 8
+  %loaded_alloca13 = load i64, ptr %local_19, align 8
+  %retval14 = call ptr @move_native_vector_borrow(ptr @__move_rttydesc_vector_u8_, ptr %loaded_alloca12, i64 %loaded_alloca13)
+  store ptr %retval14, ptr %local_20, align 8
+  %load_deref_store_tmp115 = load ptr, ptr %local_20, align 8
+  %load_deref_store_tmp216 = load { ptr, i64, i64 }, ptr %load_deref_store_tmp115, align 8
+  store { ptr, i64, i64 } %load_deref_store_tmp216, ptr %local_21, align 8
+  %call_arg_0 = load ptr, ptr %local_13, align 8
+  %call_arg_1 = load { ptr, i64, i64 }, ptr %local_21, align 8
+  call void @"0000000000000001_vector_append_9dqoPGavEhpvk5"(ptr %call_arg_0, { ptr, i64, i64 } %call_arg_1)
+  %load_store_tmp17 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp17, ptr %local_22, align 8
+  store i64 1, ptr %local_23, align 8
+  %add_src_0 = load i64, ptr %local_22, align 8
+  %add_src_1 = load i64, ptr %local_23, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_2
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_2
+  store i64 %add_dst, ptr %local_24, align 8
+  %load_store_tmp18 = load i64, ptr %local_24, align 8
+  store i64 %load_store_tmp18, ptr %local_2, align 8
+  br label %bb_3
+
+bb_0:                                             ; preds = %bb_3
+  %load_store_tmp19 = load { ptr, i64, i64 }, ptr %local_4, align 8
+  store { ptr, i64, i64 } %load_store_tmp19, ptr %local_25, align 8
+  %retval20 = load { ptr, i64, i64 }, ptr %local_25, align 8
+  ret { ptr, i64, i64 } %retval20
+}
+
+define private void @"0000000000000001_vector_append_9dqoPGavEhpvk5"(ptr noalias nonnull %0, { ptr, i64, i64 } %1) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca i1, align 1
+  %local_5 = alloca i1, align 1
+  %local_6 = alloca ptr, align 8
+  %local_7 = alloca ptr, align 8
+  %local_8 = alloca i8, align 1
+  %local_9 = alloca ptr, align 8
+  %local_10 = alloca { ptr, i64, i64 }, align 8
+  store ptr %0, ptr %local_0, align 8
+  store { ptr, i64, i64 } %1, ptr %local_1, align 8
+  store ptr %local_1, ptr %local_2, align 8
+  %call_arg_0 = load ptr, ptr %local_2, align 8
+  call void @"0000000000000001_vector_reverse_DYV9motnmmM5cs"(ptr %call_arg_0)
+  br label %bb_3
+
+bb_3:                                             ; preds = %bb_2, %entry
+  store ptr %local_1, ptr %local_3, align 8
+  %call_arg_01 = load ptr, ptr %local_3, align 8
+  %retval = call i1 @"0000000000000001_vector_is_empty_BrzErKu8hVV1SC"(ptr %call_arg_01)
+  store i1 %retval, ptr %local_4, align 1
+  %not_src = load i1, ptr %local_4, align 1
+  %not_dst = xor i1 %not_src, true
+  store i1 %not_dst, ptr %local_5, align 1
+  %cnd = load i1, ptr %local_5, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %bb_3
+  br label %bb_2
+
+bb_2:                                             ; preds = %bb_1
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_6, align 8
+  store ptr %local_1, ptr %local_7, align 8
+  %loaded_alloca = load ptr, ptr %local_7, align 8
+  call void @move_native_vector_pop_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca, ptr %local_8)
+  %loaded_alloca2 = load ptr, ptr %local_6, align 8
+  call void @move_native_vector_push_back(ptr @__move_rttydesc_u8, ptr %loaded_alloca2, ptr %local_8)
+  br label %bb_3
+
+bb_0:                                             ; preds = %bb_3
+  %load_store_tmp3 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp3, ptr %local_9, align 8
+  %load_store_tmp4 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  store { ptr, i64, i64 } %load_store_tmp4, ptr %local_10, align 8
+  call void @move_native_vector_destroy_empty(ptr @__move_rttydesc_u8, ptr %local_10)
+  ret void
+}
+
+define private void @"0000000000000001_vector_reverse_DYV9motnmmM5cs"(ptr noalias nonnull %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca ptr, align 8
+  %local_5 = alloca ptr, align 8
+  %local_6 = alloca i64, align 8
+  %local_7 = alloca i64, align 8
+  %local_8 = alloca i64, align 8
+  %local_9 = alloca i1, align 1
+  %local_10 = alloca ptr, align 8
+  %local_11 = alloca i64, align 8
+  %local_12 = alloca i64, align 8
+  %local_13 = alloca i64, align 8
+  %local_14 = alloca i64, align 8
+  %local_15 = alloca i64, align 8
+  %local_16 = alloca i64, align 8
+  %local_17 = alloca i1, align 1
+  %local_18 = alloca ptr, align 8
+  %local_19 = alloca i64, align 8
+  %local_20 = alloca i64, align 8
+  %local_21 = alloca i64, align 8
+  %local_22 = alloca i64, align 8
+  %local_23 = alloca i64, align 8
+  %local_24 = alloca i64, align 8
+  %local_25 = alloca i64, align 8
+  %local_26 = alloca i64, align 8
+  %local_27 = alloca ptr, align 8
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_4, align 8
+  %load_store_tmp1 = load ptr, ptr %local_4, align 8
+  store ptr %load_store_tmp1, ptr %local_5, align 8
+  %loaded_alloca = load ptr, ptr %local_5, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_6, align 8
+  %load_store_tmp2 = load i64, ptr %local_6, align 8
+  store i64 %load_store_tmp2, ptr %local_3, align 8
+  %load_store_tmp3 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp3, ptr %local_7, align 8
+  store i64 0, ptr %local_8, align 8
+  %eq_src_0 = load i64, ptr %local_7, align 8
+  %eq_src_1 = load i64, ptr %local_8, align 8
+  %eq_dst = icmp eq i64 %eq_src_0, %eq_src_1
+  store i1 %eq_dst, ptr %local_9, align 1
+  %cnd = load i1, ptr %local_9, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  %load_store_tmp4 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp4, ptr %local_10, align 8
+  ret void
+
+bb_0:                                             ; preds = %entry
+  store i64 0, ptr %local_11, align 8
+  %load_store_tmp5 = load i64, ptr %local_11, align 8
+  store i64 %load_store_tmp5, ptr %local_2, align 8
+  %load_store_tmp6 = load i64, ptr %local_3, align 8
+  store i64 %load_store_tmp6, ptr %local_12, align 8
+  store i64 1, ptr %local_13, align 8
+  %sub_src_0 = load i64, ptr %local_12, align 8
+  %sub_src_1 = load i64, ptr %local_13, align 8
+  %sub_dst = sub i64 %sub_src_0, %sub_src_1
+  %ovfcond = icmp ugt i64 %sub_dst, %sub_src_0
+  br i1 %ovfcond, label %then_bb, label %join_bb
+
+then_bb:                                          ; preds = %bb_0
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb:                                          ; preds = %bb_0
+  store i64 %sub_dst, ptr %local_14, align 8
+  %load_store_tmp7 = load i64, ptr %local_14, align 8
+  store i64 %load_store_tmp7, ptr %local_1, align 8
+  br label %bb_5
+
+bb_5:                                             ; preds = %join_bb28, %join_bb
+  %load_store_tmp8 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp8, ptr %local_15, align 8
+  %load_store_tmp9 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp9, ptr %local_16, align 8
+  %lt_src_0 = load i64, ptr %local_15, align 8
+  %lt_src_1 = load i64, ptr %local_16, align 8
+  %lt_dst = icmp ult i64 %lt_src_0, %lt_src_1
+  store i1 %lt_dst, ptr %local_17, align 1
+  %cnd10 = load i1, ptr %local_17, align 1
+  br i1 %cnd10, label %bb_3, label %bb_2
+
+bb_3:                                             ; preds = %bb_5
+  br label %bb_4
+
+bb_4:                                             ; preds = %bb_3
+  %load_store_tmp11 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp11, ptr %local_18, align 8
+  %load_store_tmp12 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp12, ptr %local_19, align 8
+  %load_store_tmp13 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp13, ptr %local_20, align 8
+  %loaded_alloca14 = load ptr, ptr %local_18, align 8
+  %loaded_alloca15 = load i64, ptr %local_19, align 8
+  %loaded_alloca16 = load i64, ptr %local_20, align 8
+  call void @move_native_vector_swap(ptr @__move_rttydesc_u8, ptr %loaded_alloca14, i64 %loaded_alloca15, i64 %loaded_alloca16)
+  %load_store_tmp17 = load i64, ptr %local_2, align 8
+  store i64 %load_store_tmp17, ptr %local_21, align 8
+  store i64 1, ptr %local_22, align 8
+  %add_src_0 = load i64, ptr %local_21, align 8
+  %add_src_1 = load i64, ptr %local_22, align 8
+  %add_dst = add i64 %add_src_0, %add_src_1
+  %ovfcond18 = icmp ult i64 %add_dst, %add_src_0
+  br i1 %ovfcond18, label %then_bb19, label %join_bb20
+
+then_bb19:                                        ; preds = %bb_4
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb20:                                        ; preds = %bb_4
+  store i64 %add_dst, ptr %local_23, align 8
+  %load_store_tmp21 = load i64, ptr %local_23, align 8
+  store i64 %load_store_tmp21, ptr %local_2, align 8
+  %load_store_tmp22 = load i64, ptr %local_1, align 8
+  store i64 %load_store_tmp22, ptr %local_24, align 8
+  store i64 1, ptr %local_25, align 8
+  %sub_src_023 = load i64, ptr %local_24, align 8
+  %sub_src_124 = load i64, ptr %local_25, align 8
+  %sub_dst25 = sub i64 %sub_src_023, %sub_src_124
+  %ovfcond26 = icmp ugt i64 %sub_dst25, %sub_src_023
+  br i1 %ovfcond26, label %then_bb27, label %join_bb28
+
+then_bb27:                                        ; preds = %join_bb20
+  call void @move_rt_abort(i64 4017)
+  unreachable
+
+join_bb28:                                        ; preds = %join_bb20
+  store i64 %sub_dst25, ptr %local_26, align 8
+  %load_store_tmp29 = load i64, ptr %local_26, align 8
+  store i64 %load_store_tmp29, ptr %local_1, align 8
+  br label %bb_5
+
+bb_2:                                             ; preds = %bb_5
+  %load_store_tmp30 = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp30, ptr %local_27, align 8
+  ret void
+}
+
+declare void @move_native_vector_swap(ptr, ptr, i64, i64)
+
+define private i1 @"0000000000000001_vector_is_empty_BrzErKu8hVV1SC"(ptr nonnull readonly %0) {
+entry:
+  %local_0 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i64, align 8
+  %local_4 = alloca i1, align 1
+  store ptr %0, ptr %local_0, align 8
+  %load_store_tmp = load ptr, ptr %local_0, align 8
+  store ptr %load_store_tmp, ptr %local_1, align 8
+  %loaded_alloca = load ptr, ptr %local_1, align 8
+  %retval = call i64 @move_native_vector_length(ptr @__move_rttydesc_u8, ptr %loaded_alloca)
+  store i64 %retval, ptr %local_2, align 8
+  store i64 0, ptr %local_3, align 8
+  %eq_src_0 = load i64, ptr %local_2, align 8
+  %eq_src_1 = load i64, ptr %local_3, align 8
+  %eq_dst = icmp eq i64 %eq_src_0, %eq_src_1
+  store i1 %eq_dst, ptr %local_4, align 1
+  %retval1 = load i1, ptr %local_4, align 1
+  ret i1 %retval1
+}
+
+declare void @move_native_vector_pop_back(ptr, ptr, ptr)
+
+declare void @move_native_vector_destroy_empty(ptr, ptr)
+
+define private void @"0000000000000002_hex_test_hex_decode_9fvie3eCG9NDHV"() {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.6)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_0, align 8
+  %call_arg_0 = load { ptr, i64, i64 }, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000002_hex_decode_6U7GZEKfu2EbsC"({ ptr, i64, i64 } %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_u8, ptr %local_1)
+  ret void
+}
+
+define private void @"0000000000000002_hex_test_hex_decode_BEzpj6C3ySfPPu"() {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.8)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_0, align 8
+  %call_arg_0 = load { ptr, i64, i64 }, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000002_hex_decode_6U7GZEKfu2EbsC"({ ptr, i64, i64 } %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_u8, ptr %local_1)
+  ret void
+}
+
+define private void @"0000000000000002_hex_test_hex_decode_C5G2SCi9hjo3pG"() {
+entry:
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.10)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_0, align 8
+  %call_arg_0 = load { ptr, i64, i64 }, ptr %local_0, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000002_hex_decode_6U7GZEKfu2EbsC"({ ptr, i64, i64 } %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_1, align 8
+  call void @move_rt_vec_destroy(ptr @__move_rttydesc_u8, ptr %local_1)
+  ret void
+}
+
+define private void @"0000000000000002_hex_test_hex_decode_Cv4UGXtg81zftr"() {
+entry:
+  %newv14 = alloca { ptr, i64, i64 }, align 8
+  %newv12 = alloca { ptr, i64, i64 }, align 8
+  %newv6 = alloca { ptr, i64, i64 }, align 8
+  %newv4 = alloca { ptr, i64, i64 }, align 8
+  %newv1 = alloca { ptr, i64, i64 }, align 8
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i64, align 8
+  %local_5 = alloca { ptr, i64, i64 }, align 8
+  %local_6 = alloca { ptr, i64, i64 }, align 8
+  %local_7 = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca { ptr, i64, i64 }, align 8
+  %local_11 = alloca { ptr, i64, i64 }, align 8
+  %local_12 = alloca { ptr, i64, i64 }, align 8
+  %local_13 = alloca i1, align 1
+  %local_14 = alloca i64, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.12)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_0, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %1, ptr %newv1, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv1, ptr @vdesc.14)
+  %reload2 = load { ptr, i64, i64 }, ptr %newv1, align 8
+  store { ptr, i64, i64 } %reload2, ptr %local_1, align 8
+  %call_arg_0 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000002_hex_decode_6U7GZEKfu2EbsC"({ ptr, i64, i64 } %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %2 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_0, ptr %local_2)
+  store i1 %2, ptr %local_3, align 1
+  %cnd = load i1, ptr %local_3, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i64 0, ptr %local_4, align 8
+  %call_arg_03 = load i64, ptr %local_4, align 8
+  call void @move_rt_abort(i64 %call_arg_03)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  %3 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %3, ptr %newv4, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv4, ptr @vdesc.16)
+  %reload5 = load { ptr, i64, i64 }, ptr %newv4, align 8
+  store { ptr, i64, i64 } %reload5, ptr %local_5, align 8
+  %4 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %4, ptr %newv6, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv6, ptr @vdesc.18)
+  %reload7 = load { ptr, i64, i64 }, ptr %newv6, align 8
+  store { ptr, i64, i64 } %reload7, ptr %local_6, align 8
+  %call_arg_08 = load { ptr, i64, i64 }, ptr %local_6, align 8
+  %retval9 = call { ptr, i64, i64 } @"0000000000000002_hex_decode_6U7GZEKfu2EbsC"({ ptr, i64, i64 } %call_arg_08)
+  store { ptr, i64, i64 } %retval9, ptr %local_7, align 8
+  %5 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_5, ptr %local_7)
+  store i1 %5, ptr %local_8, align 1
+  %cnd10 = load i1, ptr %local_8, align 1
+  br i1 %cnd10, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  store i64 0, ptr %local_9, align 8
+  %call_arg_011 = load i64, ptr %local_9, align 8
+  call void @move_rt_abort(i64 %call_arg_011)
+  unreachable
+
+bb_5:                                             ; preds = %bb_4
+  %6 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %6, ptr %newv12, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv12, ptr @vdesc.20)
+  %reload13 = load { ptr, i64, i64 }, ptr %newv12, align 8
+  store { ptr, i64, i64 } %reload13, ptr %local_10, align 8
+  %7 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %7, ptr %newv14, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv14, ptr @vdesc.22)
+  %reload15 = load { ptr, i64, i64 }, ptr %newv14, align 8
+  store { ptr, i64, i64 } %reload15, ptr %local_11, align 8
+  %call_arg_016 = load { ptr, i64, i64 }, ptr %local_11, align 8
+  %retval17 = call { ptr, i64, i64 } @"0000000000000002_hex_decode_6U7GZEKfu2EbsC"({ ptr, i64, i64 } %call_arg_016)
+  store { ptr, i64, i64 } %retval17, ptr %local_12, align 8
+  %8 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_10, ptr %local_12)
+  store i1 %8, ptr %local_13, align 1
+  %cnd18 = load i1, ptr %local_13, align 1
+  br i1 %cnd18, label %bb_7, label %bb_6
+
+bb_7:                                             ; preds = %bb_5
+  br label %bb_8
+
+bb_6:                                             ; preds = %bb_5
+  store i64 0, ptr %local_14, align 8
+  %call_arg_019 = load i64, ptr %local_14, align 8
+  call void @move_rt_abort(i64 %call_arg_019)
+  unreachable
+
+bb_8:                                             ; preds = %bb_7
+  ret void
+}
+
+define private void @"0000000000000002_hex_test_hex_decode_wWRsRiY3gfkAdF"() {
+entry:
+  %newv1 = alloca { ptr, i64, i64 }, align 8
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i64, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.24)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_0, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %1, ptr %newv1, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv1, ptr @vdesc.26)
+  %reload2 = load { ptr, i64, i64 }, ptr %newv1, align 8
+  store { ptr, i64, i64 } %reload2, ptr %local_1, align 8
+  %call_arg_0 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000002_hex_decode_6U7GZEKfu2EbsC"({ ptr, i64, i64 } %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %2 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_0, ptr %local_2)
+  store i1 %2, ptr %local_3, align 1
+  %cnd = load i1, ptr %local_3, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i64 0, ptr %local_4, align 8
+  %call_arg_03 = load i64, ptr %local_4, align 8
+  call void @move_rt_abort(i64 %call_arg_03)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  ret void
+}
+
+define private void @"0000000000000002_hex_test_hex_decode_9Ua87ryKqV37xz"() {
+entry:
+  %newv14 = alloca { ptr, i64, i64 }, align 8
+  %newv12 = alloca { ptr, i64, i64 }, align 8
+  %newv6 = alloca { ptr, i64, i64 }, align 8
+  %newv4 = alloca { ptr, i64, i64 }, align 8
+  %newv1 = alloca { ptr, i64, i64 }, align 8
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i64, align 8
+  %local_5 = alloca { ptr, i64, i64 }, align 8
+  %local_6 = alloca { ptr, i64, i64 }, align 8
+  %local_7 = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca { ptr, i64, i64 }, align 8
+  %local_11 = alloca { ptr, i64, i64 }, align 8
+  %local_12 = alloca { ptr, i64, i64 }, align 8
+  %local_13 = alloca i1, align 1
+  %local_14 = alloca i64, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.28)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_0, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %1, ptr %newv1, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv1, ptr @vdesc.30)
+  %reload2 = load { ptr, i64, i64 }, ptr %newv1, align 8
+  store { ptr, i64, i64 } %reload2, ptr %local_1, align 8
+  %call_arg_0 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000002_hex_decode_6U7GZEKfu2EbsC"({ ptr, i64, i64 } %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %2 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_0, ptr %local_2)
+  store i1 %2, ptr %local_3, align 1
+  %cnd = load i1, ptr %local_3, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i64 0, ptr %local_4, align 8
+  %call_arg_03 = load i64, ptr %local_4, align 8
+  call void @move_rt_abort(i64 %call_arg_03)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  %3 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %3, ptr %newv4, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv4, ptr @vdesc.32)
+  %reload5 = load { ptr, i64, i64 }, ptr %newv4, align 8
+  store { ptr, i64, i64 } %reload5, ptr %local_5, align 8
+  %4 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %4, ptr %newv6, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv6, ptr @vdesc.34)
+  %reload7 = load { ptr, i64, i64 }, ptr %newv6, align 8
+  store { ptr, i64, i64 } %reload7, ptr %local_6, align 8
+  %call_arg_08 = load { ptr, i64, i64 }, ptr %local_6, align 8
+  %retval9 = call { ptr, i64, i64 } @"0000000000000002_hex_decode_6U7GZEKfu2EbsC"({ ptr, i64, i64 } %call_arg_08)
+  store { ptr, i64, i64 } %retval9, ptr %local_7, align 8
+  %5 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_5, ptr %local_7)
+  store i1 %5, ptr %local_8, align 1
+  %cnd10 = load i1, ptr %local_8, align 1
+  br i1 %cnd10, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  store i64 0, ptr %local_9, align 8
+  %call_arg_011 = load i64, ptr %local_9, align 8
+  call void @move_rt_abort(i64 %call_arg_011)
+  unreachable
+
+bb_5:                                             ; preds = %bb_4
+  %6 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %6, ptr %newv12, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv12, ptr @vdesc.36)
+  %reload13 = load { ptr, i64, i64 }, ptr %newv12, align 8
+  store { ptr, i64, i64 } %reload13, ptr %local_10, align 8
+  %7 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %7, ptr %newv14, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv14, ptr @vdesc.38)
+  %reload15 = load { ptr, i64, i64 }, ptr %newv14, align 8
+  store { ptr, i64, i64 } %reload15, ptr %local_11, align 8
+  %call_arg_016 = load { ptr, i64, i64 }, ptr %local_11, align 8
+  %retval17 = call { ptr, i64, i64 } @"0000000000000002_hex_decode_6U7GZEKfu2EbsC"({ ptr, i64, i64 } %call_arg_016)
+  store { ptr, i64, i64 } %retval17, ptr %local_12, align 8
+  %8 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_10, ptr %local_12)
+  store i1 %8, ptr %local_13, align 1
+  %cnd18 = load i1, ptr %local_13, align 1
+  br i1 %cnd18, label %bb_7, label %bb_6
+
+bb_7:                                             ; preds = %bb_5
+  br label %bb_8
+
+bb_6:                                             ; preds = %bb_5
+  store i64 0, ptr %local_14, align 8
+  %call_arg_019 = load i64, ptr %local_14, align 8
+  call void @move_rt_abort(i64 %call_arg_019)
+  unreachable
+
+bb_8:                                             ; preds = %bb_7
+  ret void
+}
+
+define private void @"0000000000000002_hex_test_hex_encode_5pafAB9A5XGqBp"() {
+entry:
+  %newv14 = alloca { ptr, i64, i64 }, align 8
+  %newv12 = alloca { ptr, i64, i64 }, align 8
+  %newv6 = alloca { ptr, i64, i64 }, align 8
+  %newv4 = alloca { ptr, i64, i64 }, align 8
+  %newv1 = alloca { ptr, i64, i64 }, align 8
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i64, align 8
+  %local_5 = alloca { ptr, i64, i64 }, align 8
+  %local_6 = alloca { ptr, i64, i64 }, align 8
+  %local_7 = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca { ptr, i64, i64 }, align 8
+  %local_11 = alloca { ptr, i64, i64 }, align 8
+  %local_12 = alloca { ptr, i64, i64 }, align 8
+  %local_13 = alloca i1, align 1
+  %local_14 = alloca i64, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.40)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_0, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %1, ptr %newv1, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv1, ptr @vdesc.42)
+  %reload2 = load { ptr, i64, i64 }, ptr %newv1, align 8
+  store { ptr, i64, i64 } %reload2, ptr %local_1, align 8
+  %call_arg_0 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000002_hex_encode_2jkRtUUZsDAoo8"({ ptr, i64, i64 } %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %2 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_0, ptr %local_2)
+  store i1 %2, ptr %local_3, align 1
+  %cnd = load i1, ptr %local_3, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i64 0, ptr %local_4, align 8
+  %call_arg_03 = load i64, ptr %local_4, align 8
+  call void @move_rt_abort(i64 %call_arg_03)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  %3 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %3, ptr %newv4, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv4, ptr @vdesc.44)
+  %reload5 = load { ptr, i64, i64 }, ptr %newv4, align 8
+  store { ptr, i64, i64 } %reload5, ptr %local_5, align 8
+  %4 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %4, ptr %newv6, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv6, ptr @vdesc.46)
+  %reload7 = load { ptr, i64, i64 }, ptr %newv6, align 8
+  store { ptr, i64, i64 } %reload7, ptr %local_6, align 8
+  %call_arg_08 = load { ptr, i64, i64 }, ptr %local_6, align 8
+  %retval9 = call { ptr, i64, i64 } @"0000000000000002_hex_encode_2jkRtUUZsDAoo8"({ ptr, i64, i64 } %call_arg_08)
+  store { ptr, i64, i64 } %retval9, ptr %local_7, align 8
+  %5 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_5, ptr %local_7)
+  store i1 %5, ptr %local_8, align 1
+  %cnd10 = load i1, ptr %local_8, align 1
+  br i1 %cnd10, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  store i64 0, ptr %local_9, align 8
+  %call_arg_011 = load i64, ptr %local_9, align 8
+  call void @move_rt_abort(i64 %call_arg_011)
+  unreachable
+
+bb_5:                                             ; preds = %bb_4
+  %6 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %6, ptr %newv12, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv12, ptr @vdesc.48)
+  %reload13 = load { ptr, i64, i64 }, ptr %newv12, align 8
+  store { ptr, i64, i64 } %reload13, ptr %local_10, align 8
+  %7 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %7, ptr %newv14, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv14, ptr @vdesc.50)
+  %reload15 = load { ptr, i64, i64 }, ptr %newv14, align 8
+  store { ptr, i64, i64 } %reload15, ptr %local_11, align 8
+  %call_arg_016 = load { ptr, i64, i64 }, ptr %local_11, align 8
+  %retval17 = call { ptr, i64, i64 } @"0000000000000002_hex_encode_2jkRtUUZsDAoo8"({ ptr, i64, i64 } %call_arg_016)
+  store { ptr, i64, i64 } %retval17, ptr %local_12, align 8
+  %8 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_10, ptr %local_12)
+  store i1 %8, ptr %local_13, align 1
+  %cnd18 = load i1, ptr %local_13, align 1
+  br i1 %cnd18, label %bb_7, label %bb_6
+
+bb_7:                                             ; preds = %bb_5
+  br label %bb_8
+
+bb_6:                                             ; preds = %bb_5
+  store i64 0, ptr %local_14, align 8
+  %call_arg_019 = load i64, ptr %local_14, align 8
+  call void @move_rt_abort(i64 %call_arg_019)
+  unreachable
+
+bb_8:                                             ; preds = %bb_7
+  ret void
+}
+
+define private void @"0000000000000002_hex_test_hex_encode_JAfuXtAAyHiBWY"() {
+entry:
+  %newv14 = alloca { ptr, i64, i64 }, align 8
+  %newv12 = alloca { ptr, i64, i64 }, align 8
+  %newv6 = alloca { ptr, i64, i64 }, align 8
+  %newv4 = alloca { ptr, i64, i64 }, align 8
+  %newv1 = alloca { ptr, i64, i64 }, align 8
+  %newv = alloca { ptr, i64, i64 }, align 8
+  %local_0 = alloca { ptr, i64, i64 }, align 8
+  %local_1 = alloca { ptr, i64, i64 }, align 8
+  %local_2 = alloca { ptr, i64, i64 }, align 8
+  %local_3 = alloca i1, align 1
+  %local_4 = alloca i64, align 8
+  %local_5 = alloca { ptr, i64, i64 }, align 8
+  %local_6 = alloca { ptr, i64, i64 }, align 8
+  %local_7 = alloca { ptr, i64, i64 }, align 8
+  %local_8 = alloca i1, align 1
+  %local_9 = alloca i64, align 8
+  %local_10 = alloca { ptr, i64, i64 }, align 8
+  %local_11 = alloca { ptr, i64, i64 }, align 8
+  %local_12 = alloca { ptr, i64, i64 }, align 8
+  %local_13 = alloca i1, align 1
+  %local_14 = alloca i64, align 8
+  %0 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %0, ptr %newv, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv, ptr @vdesc.52)
+  %reload = load { ptr, i64, i64 }, ptr %newv, align 8
+  store { ptr, i64, i64 } %reload, ptr %local_0, align 8
+  %1 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %1, ptr %newv1, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv1, ptr @vdesc.54)
+  %reload2 = load { ptr, i64, i64 }, ptr %newv1, align 8
+  store { ptr, i64, i64 } %reload2, ptr %local_1, align 8
+  %call_arg_0 = load { ptr, i64, i64 }, ptr %local_1, align 8
+  %retval = call { ptr, i64, i64 } @"0000000000000002_hex_encode_2jkRtUUZsDAoo8"({ ptr, i64, i64 } %call_arg_0)
+  store { ptr, i64, i64 } %retval, ptr %local_2, align 8
+  %2 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_0, ptr %local_2)
+  store i1 %2, ptr %local_3, align 1
+  %cnd = load i1, ptr %local_3, align 1
+  br i1 %cnd, label %bb_1, label %bb_0
+
+bb_1:                                             ; preds = %entry
+  br label %bb_2
+
+bb_0:                                             ; preds = %entry
+  store i64 0, ptr %local_4, align 8
+  %call_arg_03 = load i64, ptr %local_4, align 8
+  call void @move_rt_abort(i64 %call_arg_03)
+  unreachable
+
+bb_2:                                             ; preds = %bb_1
+  %3 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %3, ptr %newv4, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv4, ptr @vdesc.56)
+  %reload5 = load { ptr, i64, i64 }, ptr %newv4, align 8
+  store { ptr, i64, i64 } %reload5, ptr %local_5, align 8
+  %4 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %4, ptr %newv6, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv6, ptr @vdesc.58)
+  %reload7 = load { ptr, i64, i64 }, ptr %newv6, align 8
+  store { ptr, i64, i64 } %reload7, ptr %local_6, align 8
+  %call_arg_08 = load { ptr, i64, i64 }, ptr %local_6, align 8
+  %retval9 = call { ptr, i64, i64 } @"0000000000000002_hex_encode_2jkRtUUZsDAoo8"({ ptr, i64, i64 } %call_arg_08)
+  store { ptr, i64, i64 } %retval9, ptr %local_7, align 8
+  %5 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_5, ptr %local_7)
+  store i1 %5, ptr %local_8, align 1
+  %cnd10 = load i1, ptr %local_8, align 1
+  br i1 %cnd10, label %bb_4, label %bb_3
+
+bb_4:                                             ; preds = %bb_2
+  br label %bb_5
+
+bb_3:                                             ; preds = %bb_2
+  store i64 0, ptr %local_9, align 8
+  %call_arg_011 = load i64, ptr %local_9, align 8
+  call void @move_rt_abort(i64 %call_arg_011)
+  unreachable
+
+bb_5:                                             ; preds = %bb_4
+  %6 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %6, ptr %newv12, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv12, ptr @vdesc.60)
+  %reload13 = load { ptr, i64, i64 }, ptr %newv12, align 8
+  store { ptr, i64, i64 } %reload13, ptr %local_10, align 8
+  %7 = call { ptr, i64, i64 } @move_rt_vec_empty(ptr @__move_rttydesc_u8)
+  store { ptr, i64, i64 } %7, ptr %newv14, align 8
+  call void @move_rt_vec_copy(ptr @__move_rttydesc_u8, ptr %newv14, ptr @vdesc.62)
+  %reload15 = load { ptr, i64, i64 }, ptr %newv14, align 8
+  store { ptr, i64, i64 } %reload15, ptr %local_11, align 8
+  %call_arg_016 = load { ptr, i64, i64 }, ptr %local_11, align 8
+  %retval17 = call { ptr, i64, i64 } @"0000000000000002_hex_encode_2jkRtUUZsDAoo8"({ ptr, i64, i64 } %call_arg_016)
+  store { ptr, i64, i64 } %retval17, ptr %local_12, align 8
+  %8 = call i1 @move_rt_vec_cmp_eq(ptr @__move_rttydesc_u8, ptr %local_10, ptr %local_12)
+  store i1 %8, ptr %local_13, align 1
+  %cnd18 = load i1, ptr %local_13, align 1
+  br i1 %cnd18, label %bb_7, label %bb_6
+
+bb_7:                                             ; preds = %bb_5
+  br label %bb_8
+
+bb_6:                                             ; preds = %bb_5
+  store i64 0, ptr %local_14, align 8
+  %call_arg_019 = load i64, ptr %local_14, align 8
+  call void @move_rt_abort(i64 %call_arg_019)
+  unreachable
+
+bb_8:                                             ; preds = %bb_7
+  ret void
+}
+
+declare void @move_rt_vec_destroy(ptr nonnull readonly dereferenceable(32), ptr)
+
+declare { ptr, i64, i64 } @move_rt_vec_empty(ptr nonnull readonly dereferenceable(32))
+
+declare void @move_rt_vec_copy(ptr nonnull readonly dereferenceable(32), ptr nonnull dereferenceable(24), ptr nonnull readonly dereferenceable(24))
+
+; Function Attrs: cold noreturn
+declare void @move_rt_abort(i64) #0
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare { i8, i1 } @llvm.umul.with.overflow.i8(i8, i8) #1
+
+declare i1 @move_rt_vec_cmp_eq(ptr nonnull readonly dereferenceable(32), ptr nonnull readonly dereferenceable(24), ptr nonnull readonly dereferenceable(24))
+
+attributes #0 = { cold noreturn }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call.move
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call.move
@@ -1,0 +1,73 @@
+module 0x10::debug {
+  native public fun print<T>(x: &T);
+}
+
+// module drand::hello {
+module 0x2::hello {
+    use 0x10::debug;
+    use 0x1::string;
+    use std::vector;
+
+    /// Error codes
+    const EInvalidRndLength: u64 = 0;
+
+
+    public fun create_u8_vector(): vector<u8> {
+        let v = vector::empty<u8>();
+        vector::push_back(&mut v, 72); // H
+        vector::push_back(&mut v, 101); // e
+        vector::push_back(&mut v, 108); // l
+        vector::push_back(&mut v, 108); // l
+        vector::push_back(&mut v, 111); // o
+        v
+    }
+
+    public fun print_vector_u8(vec: &vector<u8>) {
+        let vec_u8 = vector::empty<u8>();
+        let len = vector::length<u8>(vec);
+
+        let i = 0;
+        while (i < len) {
+            let byte = vector::borrow<u8>(vec, i);
+            vector::push_back<u8>(&mut vec_u8, *byte);
+            i = i + 1;
+        };
+
+        debug::print(&vec_u8);
+    }
+
+    // Converts the first 8 bytes of rnd to a u64 number and outputs its modulo with input n.
+    // Since n is u64, the output is at most 2^{-64} biased assuming rnd is uniformly random.
+    public fun safe_selection(n: u64, rnd: &vector<u8>): u64 {
+        assert!(vector::length(rnd) >= 8, EInvalidRndLength);
+        let m: u64 = 0;
+        let i = 0;
+        while (i < 8) {
+            m = m << 8;
+            let curr_byte = *vector::borrow(rnd, i);
+            m = m + (curr_byte as u64);
+            i = i + 1;
+        };
+        let n_64 = (n as u64);
+        let module_64  = m % n_64;
+        let res = (module_64 as u64);
+        res
+    }
+
+
+    public entry fun main() : u64 {
+        let s = string::utf8(b"Hello drand");
+        debug::print(&s);
+
+        let v = create_u8_vector();
+        print_vector_u8(&v);
+
+        let rand = games::drand_lib::derive_randomness(v);
+        print_vector_u8(&rand);
+
+        let rand_u64 = safe_selection(64, &rand);
+        debug::print(&rand_u64);
+
+        rand_u64
+    }
+}

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/Move.toml
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "drand-call"
+version = "1.0.0"
+
+[addresses]
+# drand = "0xba31"
+hello = "0xba31"
+
+[dependencies]
+Games = { local = "../../../../../../../sui_programmability/examples/games" }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/Move.toml
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/Move.toml
@@ -3,8 +3,8 @@ name = "drand-call"
 version = "1.0.0"
 
 [addresses]
-# drand = "0xba31"
-hello = "0xba31"
+drand = "0xba31"
+hello = "0x1"
 
 [dependencies]
 Games = { local = "../../../../../../../sui_programmability/examples/games" }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/input.json
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/input.json
@@ -1,0 +1,16 @@
+{
+    "program_id": "DozgQiYtGbdyniV2T74xMdmjZJvYDzoRFFqw7UR5MwPK",
+    "accounts": [
+        {
+            "key": "524HMdYYBy6TAn4dK5vCcjiTmT2sxV6Xoue5EXrz22Ca",
+            "owner": "BPFLoaderUpgradeab1e11111111111111111111111",
+            "is_signer": false,
+            "is_writable": true,
+            "lamports": 1000,
+            "data": [0, 0, 0, 3]
+        }
+    ],
+    "instruction_data": [
+        11, 0, 0, 0, 0, 0, 0, 0,
+        104, 101, 108, 108, 111, 95, 95, 109, 97, 105, 110]
+}

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/sources/drand-call.move
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/sources/drand-call.move
@@ -9,8 +9,7 @@ module 0x10::debug {
   native public fun print<T>(x: &T);
 }
 
-// module drand::drand {
-module hello::hello {
+module drand::hello {
     use 0x10::debug;
     use 0x1::string;
     use std::vector;

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/sources/drand-call.move
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/drand-call/sources/drand-call.move
@@ -1,0 +1,80 @@
+// input ../input.json
+// use-stdlib
+// log 0000000000000000000000000000000000000000000000000000000000000001::string::String { bytes: [72, 101, 108, 108, 111, 32, 100, 114, 97, 110, 100], }
+// log [72, 101, 108, 108, 111]
+// log [24, 95, 141, 179, 34, 113, 254, 37, 245, 97, 166, 252, 147, 139, 46, 38, 67, 6, 236, 48, 78, 218, 81, 128, 7, 209, 118, 72, 38, 56, 25, 105]
+// log 37
+
+module 0x10::debug {
+  native public fun print<T>(x: &T);
+}
+
+// module drand::drand {
+module hello::hello {
+    use 0x10::debug;
+    use 0x1::string;
+    use std::vector;
+
+    /// Error codes
+    const EInvalidRndLength: u64 = 0;
+
+
+    public fun create_u8_vector(): vector<u8> {
+        let v = vector::empty<u8>();
+        vector::push_back(&mut v, 72); // H
+        vector::push_back(&mut v, 101); // e
+        vector::push_back(&mut v, 108); // l
+        vector::push_back(&mut v, 108); // l
+        vector::push_back(&mut v, 111); // o
+        v
+    }
+
+    public fun print_vector_u8(vec: &vector<u8>) {
+        let vec_u8 = vector::empty<u8>();
+        let len = vector::length<u8>(vec);
+
+        let i = 0;
+        while (i < len) {
+            let byte = vector::borrow<u8>(vec, i);
+            vector::push_back<u8>(&mut vec_u8, *byte);
+            i = i + 1;
+        };
+
+        debug::print(&vec_u8);
+    }
+
+    // Converts the first 8 bytes of rnd to a u64 number and outputs its modulo with input n.
+    // Since n is u64, the output is at most 2^{-64} biased assuming rnd is uniformly random.
+    public fun safe_selection(n: u64, rnd: &vector<u8>): u64 {
+        assert!(vector::length(rnd) >= 8, EInvalidRndLength);
+        let m: u64 = 0;
+        let i = 0;
+        while (i < 8) {
+            m = m << 8;
+            let curr_byte = *vector::borrow(rnd, i);
+            m = m + (curr_byte as u64);
+            i = i + 1;
+        };
+        let n_64 = (n as u64);
+        let module_64  = m % n_64;
+        let res = (module_64 as u64);
+        res
+    }
+
+
+    public entry fun main() : u64 {
+        let s = string::utf8(b"Hello drand");
+        debug::print(&s);
+
+        let v = create_u8_vector();
+        print_vector_u8(&v);
+
+        let rand = games::drand_lib::derive_randomness(v);
+        print_vector_u8(&rand);
+
+        let rand_u64 = safe_selection(64, &rand);
+        debug::print(&rand_u64);
+
+        rand_u64
+    }
+}

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/sha-256/Move.toml
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/sha-256/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sha-256"
+version = "1.0.0"
+
+[addresses]
+sha_256 = "0xba31"
+hello = "0x1"
+
+[dependencies]
+MoveStdlib = { local = "../../../../../crates/move-stdlib", addr_subst = { "std" = "0x1" } }

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/sha-256/input.json
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/sha-256/input.json
@@ -1,0 +1,16 @@
+{
+    "program_id": "DozgQiYtGbdyniV2T74xMdmjZJvYDzoRFFqw7UR5MwPK",
+    "accounts": [
+        {
+            "key": "524HMdYYBy6TAn4dK5vCcjiTmT2sxV6Xoue5EXrz22Ca",
+            "owner": "BPFLoaderUpgradeab1e11111111111111111111111",
+            "is_signer": false,
+            "is_writable": true,
+            "lamports": 1000,
+            "data": [0, 0, 0, 3]
+        }
+    ],
+    "instruction_data": [
+        11, 0, 0, 0, 0, 0, 0, 0,
+        104, 101, 108, 108, 111, 95, 95, 109, 97, 105, 110]
+}

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/sha-256/sources/sha-256.move
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/rbpf-tests/sha-256/sources/sha-256.move
@@ -1,0 +1,81 @@
+// input ../input.json
+// use-stdlib
+// log 0000000000000000000000000000000000000000000000000000000000000001::string::String { bytes: [72, 101, 108, 108, 111, 32, 100, 114, 97, 110, 100], }
+// log [72, 101, 108, 108, 111]
+// log [24, 95, 141, 179, 34, 113, 254, 37, 245, 97, 166, 252, 147, 139, 46, 38, 67, 6, 236, 48, 78, 218, 81, 128, 7, 209, 118, 72, 38, 56, 25, 105]
+// log 37
+
+
+module 0x10::debug {
+  native public fun print<T>(x: &T);
+}
+
+module sha_256::hello {
+    use 0x10::debug;
+    use 0x1::string;
+    use std::vector;
+    use std::hash::sha2_256;
+
+    /// Error codes
+    const EInvalidRndLength: u64 = 0;
+
+
+    public fun create_u8_vector(): vector<u8> {
+        let v = vector::empty<u8>();
+        vector::push_back(&mut v, 72); // H
+        vector::push_back(&mut v, 101); // e
+        vector::push_back(&mut v, 108); // l
+        vector::push_back(&mut v, 108); // l
+        vector::push_back(&mut v, 111); // o
+        v
+    }
+
+    public fun print_vector_u8(vec: &vector<u8>) {
+        let vec_u8 = vector::empty<u8>();
+        let len = vector::length<u8>(vec);
+
+        let i = 0;
+        while (i < len) {
+            let byte = vector::borrow<u8>(vec, i);
+            vector::push_back<u8>(&mut vec_u8, *byte);
+            i = i + 1;
+        };
+
+        debug::print(&vec_u8);
+    }
+
+    // Converts the first 8 bytes of rnd to a u64 number and outputs its modulo with input n.
+    // Since n is u64, the output is at most 2^{-64} biased assuming rnd is uniformly random.
+    public fun safe_selection(n: u64, rnd: &vector<u8>): u64 {
+        assert!(vector::length(rnd) >= 8, EInvalidRndLength);
+        let m: u64 = 0;
+        let i = 0;
+        while (i < 8) {
+            m = m << 8;
+            let curr_byte = *vector::borrow(rnd, i);
+            m = m + (curr_byte as u64);
+            i = i + 1;
+        };
+        let n_64 = (n as u64);
+        let module_64  = m % n_64;
+        let res = (module_64 as u64);
+        res
+    }
+
+
+    public entry fun main() : u64 {
+        let s = string::utf8(b"Hello drand");
+        debug::print(&s);
+
+        let v = create_u8_vector();
+        print_vector_u8(&v);
+
+        let rand = std::hash::sha2_256(v);
+        print_vector_u8(&rand);
+
+        let rand_u64 = safe_selection(64, &rand);
+        debug::print(&rand_u64);
+
+        rand_u64
+    }
+}

--- a/external-crates/move/solana/move-mv-llvm-compiler/tests/test_common.rs
+++ b/external-crates/move/solana/move-mv-llvm-compiler/tests/test_common.rs
@@ -410,15 +410,6 @@ pub fn run_move_to_llvm_build(
     cmd.args(["-c", test]);
     cmd.args(["--extension", "ll.actual"]);
 
-    let dependency = find_toml_in_same_dir(&test);
-    if let Some(lib_dep) = dependency {
-        cmd.arg("-p");
-        cmd.arg(lib_dep.to_str().unwrap())
-    } else {
-        cmd.arg("--stdlib")
-        // cmd.arg("")
-    };
-
     for param in extra_params {
         cmd.arg(param);
     }
@@ -426,11 +417,6 @@ pub fn run_move_to_llvm_build(
 
     fs::create_dir_all(test_plan.build_dir.to_str().unwrap()).expect("Directory does not exist");
     cmd.args(["-o", test_plan.build_dir.to_str().expect("utf-8")]);
-
-    match env::current_dir() {
-        Ok(path) => println!("The current working directory is: {}", path.display()),
-        Err(e) => println!("Error retrieving current directory: {}", e),
-    }
 
     debug!(target: "launch_compiler", "{:#?}", &cmd);
 
@@ -902,17 +888,4 @@ fn generate_random_string() -> String {
         .collect();
 
     random_string
-}
-
-fn find_toml_in_same_dir(file_path: &str) -> Option<PathBuf> {
-    let path = Path::new(file_path);
-    if path.extension() == Some("move".as_ref()) {
-        if let Some(dir) = path.parent() {
-            let toml_path = dir.join("Move.toml");
-            if toml_path.exists() {
-                return Some(toml_path);
-            }
-        }
-    }
-    None
 }

--- a/external-crates/move/solana/move-to-solana/src/stackless/rttydesc.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/rttydesc.rs
@@ -353,9 +353,12 @@ impl<'mm, 'up> RttyContext<'mm, 'up> {
             _ => unreachable!(),
         };
 
+        debug!(target: "debug", "s_env {:#?}", &s_env);
+
         // Look up the corresponding LLVM struct type constructed earlier in the translation.
         // Use it to collect field offsets, struct size, and struct alignment as computed by LLVM.
         let ll_struct_name = s_env.ll_struct_name_from_raw_name(s_tys);
+        debug!(target: "rtty", "ll_struct_name {:#?}", &ll_struct_name);
         let ll_struct_ty = llcx
             .named_struct_type(&ll_struct_name)
             .expect("no struct type");

--- a/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
@@ -1851,8 +1851,9 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                     Type::Vector(bt) if bt.is_number_u8() => {
                         // This is a Constant::ByteArray element type.
 
+                        let func_name = self.env.get_full_name_str();
                         let val_vec_sz = val_vec.len();
-                        debug!(target: "debug", "val_vec size {val_vec_sz}");
+                        debug!(target: "debug", "val_vec size {val_vec_sz} in function {func_name}");
                         if !val_vec.is_empty() {
                             assert!(matches!(val_vec[0], Constant::ByteArray(_)));
                         }

--- a/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
@@ -1872,8 +1872,6 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                         return builder
                             .build_load(res_val_type, res_ptr, "reload")
                             .as_constant();
-
-
                     }
                     _ => {
                         todo!("unexpected vec constant: {}: {:#?}", val_vec.len(), val_vec);


### PR DESCRIPTION
Three tests added: 2 in rbpf and one in failures.

Two rbpf tests compiled from source and then run on VM.
Test in failure-tests is compiled only, and then .il compared against expected.

Compiler needed a for this, the fix is also in this PR. The new function `peel_vec_vec_u8` that we could not process before this fix may be found here. It is a part of Move/Sui implementation of `bcs`.

```bash
sol@dev-equinix-new-york-2:~/work/git/sui-solana-032024:060424-drand-in-failure-tests *$%$ find  /home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build -type f -exec grep --color -nH -P 'peel_vec_vec_u8' {} \+
/home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__bcs.ll.expected:2225:define { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_vec_u8_7PcPmN6rdUgmA9"(ptr noalias nonnull %0) {
/home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__bcs.ll.expected:3203:  %retval224 = call { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_vec_u8_7PcPmN6rdUgmA9"(ptr %call_arg_0223)
/home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__bcs.ll.o.asm:3509:  .globl  0000000000000002_bcs_peel_vec_vec_u8_7PcPmN6rdUgmA9 # -- Begin function 0000000000000002_bcs_peel_vec_vec_u8_7PcPmN6rdUgmA9
/home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__bcs.ll.o.asm:3511:  .type   0000000000000002_bcs_peel_vec_vec_u8_7PcPmN6rdUgmA9,@function
/home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__bcs.ll.o.asm:3512:0000000000000002_bcs_peel_vec_vec_u8_7PcPmN6rdUgmA9: # @"0000000000000002_bcs_peel_vec_vec_u8_7PcPmN6rdUgmA9"
/home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__bcs.ll.o.asm:3638:  .size   0000000000000002_bcs_peel_vec_vec_u8_7PcPmN6rdUgmA9, .Lfunc_end36-0000000000000002_bcs_peel_vec_vec_u8_7PcPmN6rdUgmA9
/home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__bcs.ll.o.asm:4788:  call 0000000000000002_bcs_peel_vec_vec_u8_7PcPmN6rdUgmA9
Binary file /home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__bcs.ll.o matches
/home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__bcs.ll.actual:2225:define { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_vec_u8_7PcPmN6rdUgmA9"(ptr noalias nonnull %0) {
/home/sol/work/git/sui-solana-032024/external-crates/move/solana/move-mv-llvm-compiler/tests/failure-tests/drand-call/drand-call-build/0x2__bcs.ll.actual:3203:  %retval224 = call { ptr, i64, i64 } @"0000000000000002_bcs_peel_vec_vec_u8_7PcPmN6rdUgmA9"(ptr %call_arg_0223)
```
