### PR TITLE
Exclude entries with generic parameters

### DIFF
--- a/external-crates/move/solana/move-mv-llvm-compiler/src/cli.rs
+++ b/external-crates/move/solana/move-mv-llvm-compiler/src/cli.rs
@@ -23,6 +23,11 @@ pub struct Args {
     #[clap(long = "skip-basic-blocks")]
     pub skip_basic_blocks: bool,
 
+    /// Skip undefined entry function.
+    // This allows to compile Sui pacages with generic entry point functions
+    #[clap(long = "skip-undefined-entries")]
+    pub skip_undefined_entries: bool,
+
     /// Treat input file as a script (default is to treat file as a module)
     #[clap(short = 's', long = "script")]
     pub is_script: bool,

--- a/external-crates/move/solana/move-mv-llvm-compiler/src/main.rs
+++ b/external-crates/move/solana/move-mv-llvm-compiler/src/main.rs
@@ -216,6 +216,7 @@ fn main() -> anyhow::Result<()> {
             bytecode_file_path: args.bytecode_file_path,
             opt_level: args.opt_level.clone(),
             print_assembly: args.print_assembly,
+            skip_undefined_entries: args.skip_undefined_entries,
             ..MoveToSolanaOptions::default()
         };
 

--- a/external-crates/move/solana/move-to-solana/src/options.rs
+++ b/external-crates/move/solana/move-to-solana/src/options.rs
@@ -49,6 +49,11 @@ pub struct Options {
     #[clap(long = "skip-basic-blocks")]
     pub skip_basic_blocks: bool,
 
+    /// Skip undefined entry function.
+    // This allows to compile Sui pacages with generic entry point functions
+    #[clap(long = "skip-undefined-entries")]
+    pub skip_undefined_entries: bool,
+
     /// Treat input file as a script (default is to treat file as a module)
     #[clap(short = 's', long = "script")]
     pub is_script: bool,

--- a/external-crates/move/solana/move-to-solana/src/stackless/entrypoint.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/entrypoint.rs
@@ -217,7 +217,6 @@ impl<'mm, 'up> EntrypointGenerator<'mm, 'up> {
         // name to the name passed in the instruction_data, and call
         // the matching entry function.
         for fun in entry_functions {
-
             let entry = self.generate_global_str_slice(fun.llvm_symbol_name_entrypoint().as_str());
 
             let func_name_ptr = self.llvm_builder.getelementptr(
@@ -261,7 +260,6 @@ impl<'mm, 'up> EntrypointGenerator<'mm, 'up> {
                 func_name_ptr,
                 func_name_len,
             ];
-
             let condition = self.llvm_builder.call(llfn, &params);
             let curr_bb = self.llvm_builder.get_insert_block();
             let then_bb = self
@@ -274,7 +272,6 @@ impl<'mm, 'up> EntrypointGenerator<'mm, 'up> {
             self.llvm_builder.position_at_end(then_bb);
             let fn_name = fun.llvm_symbol_name(&[]);
             debug!(target: "debug", "add_entries: function {fn_name}");
-
             let fn_decls = self.fn_decls.borrow();
 
             // This function may be declared as generic and then it has not been instantiated,

--- a/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
@@ -278,12 +278,12 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
 
         // The following code will collect nodes, they are not used currently and but we print them for debugging.
         let g_env = self.get_global_env();
-        let _map_node_to_type: BTreeMap<mm::NodeId, move_model::ty::Type> = g_env
+        let map_node_to_type: BTreeMap<mm::NodeId, move_model::ty::Type> = g_env
             .get_nodes()
             .iter()
             .map(|nd| (*nd, g_env.get_node_type(*nd)))
             .collect();
-        debug!(target: "nodes", "\n{:#?}", &_map_node_to_type);
+        debug!(target: "nodes", "\n{:#?}", &map_node_to_type);
 
         // Write the control flow graph to a .dot file for viewing.
         let options = &self.module_cx.options;


### PR DESCRIPTION
If compiler option `skip-undefined-entries` is set, entry point functions with a generic parameter are treated as undefined and skipped in compiler entrypoint generation.
This allows compilation of Sui packages without modification (otherwise generic functions in Sui code, mostly `test.move` files, must be modified). 

For example, this works Ok:
```bash
move-mv-llvm-compiler -c /home/sol/work/git/sui-solana-032024/crates/sui-framework/packages/sui-framework/tests/dynamic_field_tests.move -p /home/sol/work/git/sui-solana-032024/crates/sui-framework/packages/sui-framework/Move.toml --test --skip-undefined-entries -S 
```
