### PR TITLE
NFC: Move previously added code from Move crates to extensions for Solana

### DIFF
--- a/external-crates/move/crates/move-stackless-bytecode/src/stackless_bytecode.rs
+++ b/external-crates/move/crates/move-stackless-bytecode/src/stackless_bytecode.rs
@@ -104,18 +104,6 @@ impl From<&u256::U256> for Constant {
         Constant::U256(U256::from(n))
     }
 }
-impl From<&Vec<u8>> for Constant {
-    fn from(v: &Vec<u8>) -> Constant {
-        Constant::ByteArray(v.clone())
-    }
-}
-
-pub fn transform_bytearray_to_vec(val_vec: &[Constant]) -> Option<&Vec<u8>> {
-    if let Some(Constant::ByteArray(ref vec)) = val_vec.first() {
-        return Some(vec);
-    }
-    None
-}
 
 /// An operation -- target of a call. This contains user functions, builtin functions, and
 /// operators.

--- a/external-crates/move/solana/move-to-solana/src/stackless/extensions.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/extensions.rs
@@ -5,6 +5,7 @@
 //! Extension traits for foreign types.
 
 use crate::stackless::llvm;
+use move_stackless_bytecode::stackless_bytecode as sbc;
 use extension_trait::extension_trait;
 use move_binary_format::file_format::SignatureToken;
 use move_core_types::account_address;
@@ -249,6 +250,20 @@ pub impl SignatureTokenExt for SignatureToken {
             _ => {}
         };
     }
+}
+
+#[extension_trait]
+pub impl ConstantExtensions for sbc::Constant {
+    fn from_vec_u8(v: &Vec<u8>) -> sbc::Constant {
+        sbc::Constant::ByteArray(v.clone())
+    }
+}
+
+pub fn transform_bytearray_to_vec(val_vec: &[sbc::Constant]) -> Option<&Vec<u8>> {
+    if let Some(sbc::Constant::ByteArray(ref vec)) = val_vec.first() {
+        return Some(vec);
+    }
+    None
 }
 
 #[test]

--- a/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
+++ b/external-crates/move/solana/move-to-solana/src/stackless/translate.rs
@@ -1899,7 +1899,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                             assert!(matches!(val_vec[0], Constant::ByteArray(_)));
                         }
 
-                        let vec = match move_stackless_bytecode::stackless_bytecode::transform_bytearray_to_vec(&val_vec) {
+                        let vec = match transform_bytearray_to_vec(&val_vec) {
                             Some(v) => v.clone(),
                             None => {
                                 debug!(target: "constant", "No ByteArray found, using empty vector");


### PR DESCRIPTION
Some functions had been carelessly added directly to Move/Sui crates, move them to Solana crates.
